### PR TITLE
bug fix: clearInterval on loader loop

### DIFF
--- a/src/web/js/loader.js
+++ b/src/web/js/loader.js
@@ -19,6 +19,7 @@ var texts = [
     "Latching the portholes..."
   ];
 $("#loader p").text(texts[Math.floor(Math.random() * texts.length)]);
-setInterval(function() {
+var intervalID = setInterval(function() {
   $("#loader p").text(texts[Math.floor(Math.random() * texts.length)]);
 }, 1300);
+$("#loader").data("intervalID", intervalID);

--- a/src/web/js/repl.js
+++ b/src/web/js/repl.js
@@ -678,7 +678,10 @@ $(function() {
 
           $("#saveButton").click(save);
 
-          Q.all([programLoaded, interactionsReady]).fin(function() { $("#loader").hide(); });
+          Q.all([programLoaded, interactionsReady]).fin(function() {
+            clearInterval($("#loader").data("intervalID"));
+            $("#loader").hide();
+          });
           editor.focus();
         });
         done.fail(function(err) {


### PR DESCRIPTION
On CPO, the loading message ticker continues to update the DOM even after the loader element is hidden. These changes fix that.