### PR TITLE
Adding a Ctrl+I hotkey to reindent all lines (following code from https://groups.google.com/d/msg/codemirror/oGeWPzZynxo/cJoQMzkj0QoJ)

### DIFF
--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -35,11 +35,19 @@ define(["js/ffi-helpers", "js/runtime-util", "trove/image-lib", "./check-ui.js",
 
     var useLineNumbers = !options.simpleEditor;
 
+    function reindentAllLines(cm) {
+      var last = cm.lineCount();
+      cm.operation(function() {
+        for (var i = 0; i < last; ++i) cm.indentLine(i);
+      });
+    }
+
     var cmOptions = {
       extraKeys: {
         "Shift-Enter": function(cm) { runFun(cm.getValue()); },
         "Shift-Ctrl-Enter": function(cm) { runFun(cm.getValue()); },
-        "Tab": "indentAuto"
+        "Tab": "indentAuto",
+        "Ctrl-I": reindentAllLines
       },
       indentUnit: 2,
       tabSize: 2,


### PR DESCRIPTION
This should provide an equivalent experience to WeScheme's reindent-all.  It's bound to Ctrl+I, which is already a hotkey in (at least) Firefox, but as long as the editor has the keyboard focus, it works fine.  Tested on CPO/Pyret-master, and it works for me.