### PR TITLE
Expose internal pyret runtime hooks on the window object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ endif
 
 CM=node_modules/codemirror
 CPOMAIN=build/web/js/cpo-main.jarr
+CPOIDEHOOKS=build/web/js/cpo-ide-hooks.jarr
 PHASEA=pyret/build/phaseA/pyret.jarr
 
 build/web/js/pyret.js.gz:
@@ -187,7 +188,7 @@ $(NEWCSS):
 $(NEWJS):
 	@$(call MKDIR,$(NEWJS))
 
-web-local: $(WEB) $(WEBV) $(WEBJS) $(WEBJSGOOG) $(WEBCSS) $(WEBIMG) $(WEBARR) $(NEWCSS) $(NEWJS) $(OUT_HTML) $(COPY_HTML) $(OUT_CSS) $(COPY_CSS) $(COPY_JS) $(COPY_ARR) $(COPY_GIF) $(MISC_JS) $(MISC_CSS) $(MISC_IMG) $(COPY_NEW_CSS) $(COPY_NEW_JS) $(COPY_GOOGLE_JS) $(CPOMAIN)
+web-local: $(WEB) $(WEBV) $(WEBJS) $(WEBJSGOOG) $(WEBCSS) $(WEBIMG) $(WEBARR) $(NEWCSS) $(NEWJS) $(OUT_HTML) $(COPY_HTML) $(OUT_CSS) $(COPY_CSS) $(COPY_JS) $(COPY_ARR) $(COPY_GIF) $(MISC_JS) $(MISC_CSS) $(MISC_IMG) $(COPY_NEW_CSS) $(COPY_NEW_JS) $(COPY_GOOGLE_JS) $(CPOMAIN) $(CPOIDEHOOKS)
 
 web: $(WEB) $(WEBV) $(WEBJS) $(WEBJSGOOG) $(WEBCSS) $(WEBIMG) $(WEBARR) $(NEWCSS) $(NEWJS) $(OUT_HTML) $(COPY_HTML) $(OUT_CSS) $(COPY_CSS) $(COPY_JS) $(COPY_ARR) $(COPY_GIF) build/web/js/pyret.js.gz $(MISC_JS) $(MISC_CSS) $(MISC_IMG) $(COPY_NEW_CSS) $(COPY_NEW_JS) $(COPY_GOOGLE_JS)
 
@@ -195,7 +196,7 @@ link-pyret:
 	ln -s node_modules/pyret-lang pyret;
 	cd node_modules/pyret-lang && $(MAKE) phaseA-deps && cd ../../;
 
-deploy-cpo-main: link-pyret $(CPOMAIN)
+deploy-cpo-main: link-pyret $(CPOMAIN) $(CPOIDEHOOKS)
 
 TROVE_JS := $(wildcard src/web/js/trove/*.js)
 
@@ -219,6 +220,21 @@ $(CPOMAIN): $(TROVE_JS) $(WEBJS) src/web/js/*.js src/web/arr/*.arr cpo-standalon
     --standalone-file cpo-standalone.js \
     --compiled-dir ./compiled \
     --outfile $(CPOMAIN) -no-check-mode
+
+$(CPOIDEHOOKS): $(TROVE_JS) $(WEBJS) src/web/js/*.js src/web/arr/*.arr cpo-standalone.js cpo-config.json src/web/arr/cpo-ide-hooks.arr $(PHASEA)
+	mkdir -p compiled/;
+	cp pyret/build/phaseA/compiled/*.js ./compiled/
+	node pyret/build/phaseA/pyret.jarr \
+    --builtin-js-dir src/web/js/trove/ \
+    --builtin-js-dir pyret/src/js/trove/ \
+    -allow-builtin-overrides \
+    --builtin-arr-dir src/web/arr/trove/ \
+    --builtin-arr-dir pyret/src/arr/trove/ \
+    --require-config cpo-config.json \
+    --build-runnable src/web/arr/cpo-ide-hooks.arr \
+    --standalone-file cpo-standalone.js \
+    --compiled-dir ./compiled \
+    --outfile $(CPOIDEHOOKS) -no-check-mode
 
 clean:
 	rm -rf build/

--- a/src/web/arr/cpo-ide-hooks.arr
+++ b/src/web/arr/cpo-ide-hooks.arr
@@ -1,0 +1,1 @@
+import js-file("../js/cpo-ide-hooks") as T

--- a/src/web/js/authenticate-storage.js
+++ b/src/web/js/authenticate-storage.js
@@ -1,9 +1,10 @@
 // Defines storageAPI (as a promise) for others to use
 var storageAPIDeferred = Q.defer();
 var sheetsAPIDeferred = Q.defer();
-var storageAPI = storageAPIDeferred.promise;
-var sheetsAPI = sheetsAPIDeferred.promise;
-function handleClientLoad(clientId, apiKey) {
+window.storageAPI = storageAPIDeferred.promise;
+window.sheetsAPI = sheetsAPIDeferred.promise;
+
+window.handleClientLoad = function handleClientLoad(clientId, apiKey) {
   gapi.client.setApiKey(apiKey);
   var api = createProgramCollectionAPI("code.pyret.org", true);
 
@@ -36,4 +37,3 @@ function handleClientLoad(clientId, apiKey) {
     };
   });
 }
-

--- a/src/web/js/cpo-ide-hooks.js
+++ b/src/web/js/cpo-ide-hooks.js
@@ -1,0 +1,57 @@
+({
+  requires: [
+    { "import-type": "dependency",
+      protocol: "file",
+      args: ["../../../pyret/src/arr/compiler/compile-lib.arr"]
+    },
+    { "import-type": "dependency",
+      protocol: "file",
+      args: ["../../../pyret/src/arr/compiler/compile-structs.arr"]
+    },
+    { "import-type": "dependency",
+      protocol: "file",
+      args: ["../../../pyret/src/arr/compiler/repl.arr"]
+    },
+    { "import-type": "dependency",
+      protocol: "file",
+      args: ["../arr/cpo.arr"]
+    },
+    { "import-type": "builtin",
+      name: "runtime-lib"
+    },
+    { "import-type": "builtin",
+      name: "load-lib"
+    },
+    { "import-type": "builtin",
+      name: "builtin-modules"
+    },
+    { "import-type": "builtin",
+      name: "cpo-builtins"
+    }
+  ],
+  nativeRequires: [
+    "cpo/cpo-builtin-modules"
+  ],
+  provides: {},
+  theModule: function(runtime, namespace, uri,
+                      compileLib, compileStructs, pyRepl, cpo,
+                      runtimeLib, loadLib, builtinModules, cpoBuiltins,
+                      cpoModules
+  ) {
+    window.CPOIDEHooks = {
+      runtime: runtime,
+      namespace: namespace,
+      uri: uri,
+      compileLib: compileLib,
+      compileStructs: compileStructs,
+      pyRepl: pyRepl,
+      cpo: cpo,
+      runtimeLib: runtimeLib,
+      loadLib: loadLib,
+      builtinModules: builtinModules,
+      cpoBuiltins: cpoBuiltins,
+      cpoModules: cpoModules,
+    };
+    return runtime.makeModuleReturn({}, {});
+  }
+})

--- a/src/web/js/google-apis/api-wrapper.js
+++ b/src/web/js/google-apis/api-wrapper.js
@@ -8,7 +8,7 @@
  * The most recently authenticated version of the
  * wrapped Google API
  */
-var gwrap = {
+var gwrap = window.gwrap = {
   // Initialize to a dummy method which loads the wrapper
   load: function(params) {
     if (!params || !params.reauth || (params.reauth.immediate === undefined)) {
@@ -44,7 +44,7 @@ var _GWRAP_APIS = {};
  *        on `reauth`.
  */
 function loadAPIWrapper(immediate) {
-  
+
   // Sanity check: Make sure aforementioned things are
   //               actually defined.
 

--- a/src/web/js/google-apis/drive.js
+++ b/src/web/js/google-apis/drive.js
@@ -1,4 +1,4 @@
-function createProgramCollectionAPI(collectionName, immediate) {
+window.createProgramCollectionAPI = function createProgramCollectionAPI(collectionName, immediate) {
   function DriveError(err) {
     this.err = err;
   }
@@ -117,7 +117,7 @@ function createProgramCollectionAPI(collectionName, immediate) {
         save: function(contents, newRevision) {
           // NOTE(joe): newRevision: false will cause badRequest errors as of
           // April 30, 2014
-          if(newRevision) { 
+          if(newRevision) {
             var params = { 'newRevision': true };
           }
           else {
@@ -156,9 +156,9 @@ function createProgramCollectionAPI(collectionName, immediate) {
 
     // The primary purpose of this is to have some sort of fallback for
     // any situation in which the file object has somehow lost its info
-    function fileBuilder(googFileObject) { 
-      if ((googFileObject.mimeType === 'text/plain' && !googFileObject.fileExtension) 
-          || googFileObject.fileExtension === 'arr') { 
+    function fileBuilder(googFileObject) {
+      if ((googFileObject.mimeType === 'text/plain' && !googFileObject.fileExtension)
+          || googFileObject.fileExtension === 'arr') {
         return makeFile(googFileObject, 'text/plain', 'arr');
       } else {
         return makeFile(googFileObject, googFileObject.mimeType, googFileObject.fileExtension);

--- a/src/web/js/share.js
+++ b/src/web/js/share.js
@@ -1,4 +1,4 @@
-function makeShareAPI(pyretVersion) {
+window.makeShareAPI = function makeShareAPI(pyretVersion) {
 
   function makeHoverMenu(triggerElt, menuElt, showOnHover, onShow) {
     var divHover = false;


### PR DESCRIPTION
This will make it easier to hook into the pyret runtime without having to compile jarr files... which in turn will make UI development easier.