### PR TITLE
Enable support for code-folding in CPO editor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,10 @@ build/web/neweditor/js/%.js: src/web/neweditor/js/%.js
 build/web/css/codemirror.css: $(CM)/lib/codemirror.css
 	cp $< $@
 
-MISC_CSS = build/web/css/codemirror.css
+build/web/css/foldgutter.css: $(CM)/addon/fold/foldgutter.css
+	cp $< $@
+
+MISC_CSS = build/web/css/codemirror.css build/web/css/foldgutter.css
 
 COPY_GIF := $(patsubst src/web/img/%.gif,build/web/img/%.gif,$(wildcard src/web/img/*.gif))
 
@@ -124,6 +127,12 @@ build/web/js/pyret-fold.js: src/web/js/codemirror/pyret-fold.js
 build/web/js/matchkw.js: src/web/js/codemirror/matchkw.js
 	cp $< $@
 
+build/web/js/foldcode.js: $(CM)/addon/fold/foldcode.js
+	cp $< $@
+
+build/web/js/foldgutter.js: $(CM)/addon/fold/foldgutter.js
+	cp $< $@
+
 build/web/js/pyret-mode.js: src/web/js/codemirror/pyret-mode.js
 	cp $< $@
 
@@ -134,6 +143,8 @@ MISC_JS = build/web/js/q.js build/web/js/url.js build/web/js/require.js \
           build/web/js/seedrandom.js \
           build/web/js/pyret-fold.js \
           build/web/js/matchkw.js \
+          build/web/js/foldcode.js \
+          build/web/js/foldgutter.js \
           build/web/js/colorspaces.js \
           build/web/js/es6-shim.js \
           build/web/js/runmode.js

--- a/src/web/editor.template.html
+++ b/src/web/editor.template.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="/css/reset.css"></link>
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
   <link rel="stylesheet" href="/css/codemirror.css"></link>
+  <link rel="stylesheet" href="/css/foldgutter.css"></link>
   <link rel="stylesheet" href="/css/shared.css"></link>
   <link rel="stylesheet" href="/css/editor.css"></link>
   <link rel="icon" type="image/png" href="/img/pyret-icon.png">
@@ -109,6 +110,8 @@
 <script src="/js/colorspaces.js"></script>
 <script src="/js/q.js"></script>
 <script src="/js/codemirror.js"></script>
+<script src="/js/foldcode.js"></script>
+<script src="/js/foldgutter.js"></script>
 <script src="/js/mark-selection.js"></script>
 <script src="/js/runmode.js"></script>
 <script src="/js/pyret-mode.js"></script>

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -113,7 +113,7 @@ $(function() {
       matchBrackets: true,
       styleSelectedText: true,
       foldGutter: true,
-      gutters: ["CodeMirror-linenumbers", "test-marker-gutter"],
+      gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter", "test-marker-gutter"],
       lineWrapping: true
     };
 

--- a/src/web/js/codemirror/pyret-mode.js
+++ b/src/web/js/codemirror/pyret-mode.js
@@ -53,9 +53,10 @@ CodeMirror.defineMode("pyret", function(config, parserConfig) {
                                 OPENING : 1,      // Opening token (e.g. "fun", "{")
                                 CLOSING : 2,      // Closing token (e.g. "end", "}")
                                 SUBKEYWORD : 3,   // Subkeyword (e.g. "else if")
-                                OPEN_CONTD : 4,   // Extension of opening keyword (i.e. function names & ":")
+                                OPEN_CONTD : 4,   // Extension of opening keyword (e.g. ":")
                                 CLOSE_CONTD : 5,  // Extension of closing keyword (UNUSED)
-                                SUB_CONTD : 6};    // Extension of subkeyword (i.e. colon after "else if")
+                                SUB_CONTD : 6,    // Extension of subkeyword (i.e. colon after "else if")
+                                FOLD_OPEN_CONTD : 7}; // Extension of opening keyword (acts like OPEN_CONTD *when folding*)
 
   // Contexts in which function-names can be unprefixed
   // (i.e. no "fun" or "method")
@@ -376,9 +377,18 @@ CodeMirror.defineMode("pyret", function(config, parserConfig) {
       ls.nestingsAtLineStart = ls.nestingsAtLineEnd.copy();
     }
     // Special case: period-separated names in for <func>(...) expressions
-    if ((state.lastToken === "name" || state.lastToken === ".") && hasTop(ls.tokens, "WANTCOLONORBLOCK", "FOR")) {
+    // Philip: disabling for now, since this is only useful for staying visible when folding...
+    //         ...not to mention that it's been broken for who-knows-how-long and no one has
+    //         noticed since it's not even really used
+    /*if ((state.lastToken === "name" || state.lastToken === ".") && hasTop(ls.tokens, ["WANTCOLONORBLOCK", "FOR"])) {
       if (inOpening)
         ls.delimType = pyret_delimiter_type.OPEN_CONTD;
+    }*/
+    // Special case: don't hide function-names when folding
+    if ((state.lastToken === "name") && (style === 'function-name')
+        && (hasTop(ls.tokens, ["WANTOPENPAREN", "WANTCLOSEPAREN", "WANTCOLONORBLOCK", "FUN"]))) {
+      if (inOpening) // Slightly redundant, but let's be safe
+        ls.delimType = pyret_delimiter_type.FOLD_OPEN_CONTD;
     }
     // Uncomment if pyret_unprefixed_contexts is ever used again
     /*if (state.lastToken === "name" && style === 'function-name' && isUnprefixedContext(ls.tokens)) {


### PR DESCRIPTION
This Pull Request adds the ability to fold regions of code inside of the CPO editor. *With the exception of parentheses* (since that just clutters the gutter), this adds the ability to fold code between any pair of matched keywords/delimiters that CPO currently highlights.

Examples:

No folding:

![Code unfolded][fold-1]

Folding of inner `for...end` expression (note the toggling button on the side gutter):

![for...end folded][fold-2]

As a special case, `fun` and `method` keep their names visible:

![fun folded][fold-3]

Possible enhancements:
- Make `data` keep its name visible (requires not-exactly-trivial finagling of `parse` in `pyret-mode.js`)
- Keep arguments visible in `fun`/`method` (perhaps just keep everything between keywords and their matching colons visible?)
- Add keybinding to toggle folding

[fold-1]: https://belph.github.io/photo/fold1.png
[fold-2]: https://belph.github.io/photo/fold2.png
[fold-3]: https://belph.github.io/photo/fold3.png