### PR TITLE
Add drive-view to list of IDs in the "More" menu

### DIFF
--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -574,7 +574,8 @@ body {
 #docs *,
 #issues *,
 #discuss *,
-#logout * {
+#logout *,
+#drive-view * {
   color: #000;
   font-family: sans-serif;
   text-decoration: none;


### PR DESCRIPTION
The "View in Google Drive" link looked different. It was an underlined purple link instead of a block link like the rest of the links in the "More" section. This fixes that.