### PR TITLE
canonicalizeAngle: avoid while-loop when converting angle to [0, 360)

### DIFF
--- a/src/web/js/trove/image.js
+++ b/src/web/js/trove/image.js
@@ -244,13 +244,9 @@
 
     var canonicalizeAngle = function(angle) {
       angle = checkReal(angle);
-      while (jsnums.lessThan(angle, 0)) {
+      angle = jsnums.remainder(angle, 360);
+      if (jsnums.lessThan(angle, 0)) {
         angle = jsnums.add(angle, 360);
-        //angle += 360;
-      }
-      while (jsnums.greaterThanOrEqual(angle, 360)) {
-        angle = jsnums.subtract(angle, 360);
-        //angle -= 360;
       }
       return angle;
     };


### PR DESCRIPTION
Using `while` causes hang for very large angles.