### PR TITLE
render roughnum with trailing ellipsis

### DIFF
--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -1126,6 +1126,8 @@
           });
 
           return outText;
+        } else if (jsnums.isRoughnum(num)) {
+          return renderText(sooper(renderers, "number", num.toString() + '...'));
         } else {
           return renderText(sooper(renderers, "number", num));
         }


### PR DESCRIPTION
Fix for brownplt/pyret-lang#664.

(This modifies the renderer for roughnums rather than changing `Roughnum.prototype.toString`, which breaks too many tests, because `toString` isn't called only by the renderer.)