### PR TITLE
empty-color-scene

### DIFF
--- a/src/web/js/trove/image-lib.js
+++ b/src/web/js/trove/image-lib.js
@@ -319,6 +319,7 @@
     colorDb.put("DIM GRAY", makeColor(105, 105, 105));
     colorDb.put("DIMGRAY", makeColor(105, 105, 105));
     colorDb.put("BLACK", makeColor(0, 0, 0));
+    colorDb.put("TRANSPARENT", makeColor(0, 0, 0, 0));
 
     // clone: object -> object
     // Copies an object.  The new object should respond like the old
@@ -746,12 +747,13 @@
 
     //////////////////////////////////////////////////////////////////////
     // SceneImage: primitive-number primitive-number (listof image) -> Scene
-    var SceneImage = function(width, height, children, withBorder) {
+    var SceneImage = function(width, height, children, withBorder, color) {
       BaseImage.call(this);
       this.width    = width;
       this.height   = height;
       this.children = children; // arrayof [image, number, number]
       this.withBorder = withBorder;
+      this.color = color;
       this.ariaText = " scene that is "+width+" by "+height+". children are: ";
       this.ariaText += children.map(function(c,i){
         return "child "+(i+1)+": "+c[0].ariaText+", positioned at "+c[1]+","+c[2]+" ";
@@ -766,7 +768,8 @@
                             this.children.concat([[anImage,
                                                    x - anImage.getWidth()/2,
                                                    y - anImage.getHeight()/2]]),
-                            this.withBorder);
+                            this.withBorder,
+                            this.color);
     };
 
     // render: 2d-context primitive-number primitive-number -> void
@@ -774,7 +777,8 @@
       var childImage, childX, childY;
       // create a clipping region around the boundaries of the Scene
       ctx.save();
-      ctx.fillStyle = "rgba(0,0,0,0)";
+      //ctx.fillStyle = "rgba(0,0,0,0)";
+      ctx.fillStyle = this.color? colorString(this.color) : 'transparent';
       ctx.fillRect(x, y, this.width, this.height);
       ctx.restore();
       // save the context, reset the path, and clip to the path around the scene edge
@@ -1628,8 +1632,8 @@
       return makeImageDataImage(imageData);
     };
 
-    var makeSceneImage = function(width, height, children, withBorder) {
-      return new SceneImage(width, height, children, withBorder);
+    var makeSceneImage = function(width, height, children, withBorder, color) {
+      return new SceneImage(width, height, children, withBorder, color);
     };
     var makeCircleImage = function(radius, style, color) {
       return new EllipseImage(2*radius, 2*radius, style, color);

--- a/src/web/js/trove/image.js
+++ b/src/web/js/trove/image.js
@@ -34,6 +34,7 @@
       "above": "tany",
       "above-align": "tany",
       "empty-scene": "tany",
+      "empty-color-scene": "tany",
       "put-image": "tany",
       "place-image": "tany",
       "place-image-align": "tany",
@@ -534,6 +535,15 @@
       var height = checkNonNegativeReal(maybeHeight);
       return makeImage(
         image.makeSceneImage(jsnums.toFixnum(width), jsnums.toFixnum(height), [], true));
+    });
+    f("empty-color-scene", function(maybeWidth, maybeHeight, maybeColor) {
+      checkArity(3, arguments, "empty-color-scene");
+      c("empty-color-scene", [maybeWidth, maybeHeight, maybeColor], [annNumNonNegative, annNumNonNegative, annColor]);
+      var width = checkNonNegativeReal(maybeWidth);
+      var height = checkNonNegativeReal(maybeHeight);
+      var color = checkColor(maybeColor);
+      return makeImage(
+        image.makeSceneImage(jsnums.toFixnum(width), jsnums.toFixnum(height), [], true, color));
     });
     f("put-image", function(maybePicture, maybeX, maybeY, maybeBackground) {
       checkArity(4, arguments, "put-image");


### PR DESCRIPTION
Fix for #181.

`empty-color-scene(20, 20, "purple")` returns an empty 20x20 scene with a purple background.