### PR TITLE
makeScaleImage: flip image appropriately when xFactor and/or yFactor are negative

### DIFF
--- a/src/web/js/trove/image-lib.js
+++ b/src/web/js/trove/image-lib.js
@@ -1177,8 +1177,8 @@
       });
 
       this.img      = img;
-      this.width    = img.width * xFactor;
-      this.height   = img.height * yFactor;
+      this.width    = img.width * Math.abs(xFactor);
+      this.height   = img.height * Math.abs(yFactor);
       this.xFactor  = xFactor;
       this.yFactor  = yFactor;
       this.ariaText = "Scaled Image, "+ (xFactor===yFactor? "by "+xFactor
@@ -1193,6 +1193,12 @@
     ScaleImage.prototype.render = function(ctx, x, y) {
       ctx.save();
       ctx.scale(this.xFactor, this.yFactor);
+      if (this.xFactor < 0) {
+        ctx.translate((this.width+2*x)/(this.xFactor), 0);
+      }
+      if (this.yFactor < 0) {
+        ctx.translate(0, (this.height+2*y)/(this.yFactor));
+      }
       this.img.render(ctx, x / this.xFactor, y / this.yFactor);
       ctx.restore();
     };
@@ -1692,14 +1698,6 @@
       return new RotateImage(angle, img);
     };
     var makeScaleImage = function(xFactor, yFactor, img) {
-      if (xFactor < 0) {
-        xFactor = -xFactor;
-        img = makeFlipImage(img, 'horizontal');
-      }
-      if (yFactor < 0) {
-        yFactor = -yFactor;
-        img = makeFlipImage(img, 'vertical');
-      }
       return new ScaleImage(xFactor, yFactor, img);
     };
     var makeCropImage = function(x, y, width, height, img) {

--- a/src/web/js/trove/image-lib.js
+++ b/src/web/js/trove/image-lib.js
@@ -1692,6 +1692,14 @@
       return new RotateImage(angle, img);
     };
     var makeScaleImage = function(xFactor, yFactor, img) {
+      if (xFactor < 0) {
+        xFactor = -xFactor;
+        img = makeFlipImage(img, 'horizontal');
+      }
+      if (yFactor < 0) {
+        yFactor = -yFactor;
+        img = makeFlipImage(img, 'vertical');
+      }
       return new ScaleImage(xFactor, yFactor, img);
     };
     var makeCropImage = function(x, y, width, height, img) {


### PR DESCRIPTION
Fix for brownplt/pyret-lang#1122.

Here's a test you can try: negative xFactor flips right<->left; negative yFactor up<->down.

```
include image

lion = bitmap-url('http://ds26gte.github.io/tex2page/t2p.png')

lion-left = scale-xy(-1, 1, lion)

lion-down = scale-xy(1, -1, lion)
```