### PR TITLE
skip tests that rely on GOOGLE_CLIENT_ID for pulls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ before_script:
 - sleep 3
 script:
 - sleep 3
-- heroku local:run node_modules/.bin/mocha
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; heroku local:run node_modules/.bin/mocha; fi
+- if [ "$TRAVIS_PULL_REQUEST" = "true" ]; heroku local:run node_modules/.bin/mocha --grep modules --invert; fi
 #addons:
 #  sauce_connect: true
 #- mocha --harmony

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ before_script:
 - sleep 3
 script:
 - sleep 3
-- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; heroku local:run node_modules/.bin/mocha; fi
-- if [ "$TRAVIS_PULL_REQUEST" = "true" ]; heroku local:run node_modules/.bin/mocha --grep modules --invert; fi
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then heroku local:run node_modules/.bin/mocha; fi
+- if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then heroku local:run node_modules/.bin/mocha --grep modules --invert; fi
 #addons:
 #  sauce_connect: true
 #- mocha --harmony


### PR DESCRIPTION
This avoids issues where needing encrypted credentials makes Travis fail because it can't find shared GDrive files.