### PR TITLE
Make Run dropdown sleek again; and other issues following a11y update

### DIFF
--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -1227,8 +1227,9 @@ code div {
   box-shadow: 0px -5px 5px 1px rgba(0,0,0,0.2);
 }
 
-#runButton{
+#runButton, #runDropdown {
   background: #317BCF;
+  color: #eee;
 }
 
 #runButton:hover{
@@ -1266,40 +1267,68 @@ code div {
   margin: 0;
 }
 
-#run-dropdown-content li {
-  background: #317BCF;
-}
-
-/*
-.dropdown {
-  background: #317BCF;
-  padding-top: 12px;
-  padding-left: 5px;
-  box-sizing: border-box;
-  float: right;
+#rundropdownli {
+  padding: 0;
+  margin: 0;
   height: 100%;
   width: 20px;
+  background: #317bcf;
+}
+
+#rundropdownli > div {
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.dropdown {
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  padding-top: 12px;
+  padding-left: 5px;
+  border: 0;
   box-shadow: 0px -2px 5px 2px rgba(0, 0, 0, 0.1);
 }
 
-#run-dropdown-content {
-  position: absolute;
-  right: 153px;
-  top: 40px;
-  margin: 0;
-  width: 172px;
-  display: none; 
+#select-run a {
+  color: #eeeeee;
+  text-decoration: none;
 }
 
-#run-dropdown-content li {
+#select-tc-run a {
+  color: #eeeeee;
+  text-decoration: none;
+}
+
+
+#run-dropdown-content {
+  width: 163px;
+}
+
+#run-dropdown-content > li {
+  background: #317BCF;
   color: #eeeeee;
   font-family: sans-serif;
   font-size: 15px;
   height: 23px;
+  width: 100%;
   background: #317BCF;
   padding: 5px;
   box-shadow: 0px -2px 5px 2px rgba(0, 0, 0, 0.1);
   text-align: center;
+}
+
+#run-dropdown-content > li > div {
+  height: 100%;
+  width: 100%;
+  padding: 0;
+}
+
+#run-dropdown-content > li > div > a {
+  height: 100%;
+  width: 100%;
+  padding: 0;
 }
 
 #run-dropdown-content li:hover {
@@ -1312,7 +1341,6 @@ code div {
   box-shadow: 0px -5px 10px 5px rgba(0, 0, 0, 0.3);
   background:#0060CE;
 }
-*/
 
 .module-info-hover {
   width: 30em;
@@ -1931,9 +1959,7 @@ button.controller {
   margin: auto;
   display: block;
 }
-.hidden {
-  display: none
-}
+
 .screenreader-only {
     position: absolute !important;
     height: 1px;

--- a/src/web/css/shared.css
+++ b/src/web/css/shared.css
@@ -1,4 +1,3 @@
-
 body {
   line-height: 1.3;
 }
@@ -210,14 +209,14 @@ nav a, nav button {
 }
 
 nav > ul {
-  height: 100%; 
+  height: 100%;
   margin: 0;
   padding: 0;
   list-style-type: none;
 }
 
 nav > ul > li {
-  height: 100%; 
+  height: 100%;
   margin: 0;
   padding: 0;
   position: relative;
@@ -226,14 +225,21 @@ nav > ul > li {
 }
 
 nav > ul > li  ul {
-   position: absolute; 
-  top: 2.5em; 
+  position: absolute;
+  top: 2.5em;
   margin: 0;
   padding: 0;
-  left: 0;
   aria-hidden: true;
   display: none;
   list-style-type: none;
+}
+
+nav > ul > li > ul:not([id="run-dropdown-content"]) {
+  left: 0;
+}
+
+nav > ul > li > ul[id="run-dropdown-content"] {
+  left: -150px;
 }
 
 nav > ul > li:focus ul {
@@ -331,7 +337,6 @@ li.rhs > div {
   bottom: 0;
   width: 100%;
 }
-
 
 .blueButton {
     font-family: sans-serif;

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -104,7 +104,7 @@
               <span>▾ File</span><span id="filename"></span>
             </button>
           </div>
-          <!-- <div id="filemenuContents" class="menuContents" style="display: none; z-index: 8990;"> -->
+          <!-- div id="filemenuContents" class="menuContents" style="display: none; z-index: 8990;" -->
           <ul id="filemenuContents" class="menuContents" role="menu" aria-hidden="true"
             aria-label="File Menu">
             <li>
@@ -183,8 +183,8 @@
         </li>
       </ul>
     </nav>
-
   </div>
+
 <div id="toolbar"></div>
 <div id="loader"><p>Raising the masts...</p></div>
 <div id="main">

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -18,7 +18,40 @@
   <main>
   <div id="Toolbar" role="region" aria-label="Tool Controls" tabindex="-1">
     <nav aria-label="Toolbar" id="header">
-      <h2 class="screenreader-only">Navigation Controls</h2>
+      <h2 class="screenreader-only">Navigation Controls
+        <div class="screenreader-only">
+          <p class="screenreader-only" id="bonniemenubuttonInfo">Main submenu.
+          Use up and down arrows to navigate this submenu.
+          Click, enter, or space to choose a submenu item.
+          Use left and right arrows to go to adjacent menu items.
+          Press Control question mark for Help.</p>
+          <p class="screenreader-only" id="connectButtonInfo">Connect button.
+          Click, enter, or space to connect to Google Drive.
+          Use left and right arrows to go to adjacent menu items.</p>
+          <p class="screenreader-only" id="filemenuItemInfo">File submenu.
+          Use up and down arrows to navigate this submenu.
+          Click, enter, or space to choose a submenu item.
+          Use left and right arrows to go to adjacent menu items.</p>
+          <p class="screenreader-only" id="insertInfo">Insert button.
+          Click, enter, or space to open Insert dialog.
+          Keyboard shortcut: F11.
+          Use left and right arrows to go to adjacent menu items.</p>
+          <p class="screenreader-only" id="publishInfo">Share button.
+          Click, enter, or space to open publish dialog.
+          Use left and right arrows to go to adjacent menu items.</p>
+          <p class="screenreader-only" id="breakButtonInfo">Stop button.
+          Click, enter, or space to stop currently running program.
+          Use left and right arrows to go to adjacent menu items.</p>
+          <p class="screenreader-only" id="runDropdownInfo">Run options dropdown submenu.
+          Use up and down arrows to navigate this submenu.
+          Use left and right arrows to go to adjacent menu items.
+          Click, enter, or space to choose an option.</p>
+          <p class="screenreader-only" id="runButtonInfo">Run button.
+          Click, enter, or space to run current definitions window.
+          Keyboard shortcut: F7.
+          Use left and right arrows to go to adjacent menu items.</p>
+        </div>
+      </h2>
       <ul id="topTierUl" role="tree" aria-label="Toolbar" tabindex="-1">
         <li class="lhs topTier" id="bonniemenuli">
           <div id="bonniemenu" class="menu menuitemtitle" style="float:none" >
@@ -28,11 +61,20 @@
                     aria-haspopup="true"
                     aria-expanded="false"
                     aria-controls="bonniemenuContents"
-                    tabindex="0"
+                    aria-describedby="bonniemenubuttonInfo"
+                    tabindex="-1"
                     class="blueButton focusable">
               <span>▾</span>
               <img class="logo" src="/img/pyret-logo.png"></img>
             </button>
+          </div>
+          <div class="screenreader-only">
+            <p class="screenreader-only myProgramsInfo">My Programs</p>
+            <p class="screenreader-only documentationInfo">Documentation</p>
+            <p class="screenreader-only reportIssueInfo">Report an issue</p>
+            <p class="screenreader-only discussPyretInfo">Discuss Pyret</p>
+            <p class="screenreader-only detailedLoggingInfo">Contrinute detailed usage information</p>
+            <p class="screenreader-only logoutInfo">Log out</p>
           </div>
           <ul id="bonniemenuContents" class="menuContents" role="menu" aria-hidden="true"
             aria-label="Main Menu">
@@ -43,12 +85,16 @@
             </li>
             <li>
               <div id="drive-view" class="loginOnly menuButton">
-                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="/">My Programs</a>
+                <a class="focusable"
+                  aria-describedby="myProgramsInfo" role="treeitem" tabindex="-1" target="_blank" href="/">
+                  My Programs</a>
               </div>
             </li>
             <li >
               <div id="docs" class="menuButton">
-                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="http://pyret.org/docs/{{{ CURRENT_PYRET_DOCS }}}">Documentation</a>
+                <a class="focusable"
+                  aria-describedby="documentationInfo"
+                  role="treeitem" tabindex="-1" target="_blank" href="http://pyret.org/docs/{{{ CURRENT_PYRET_DOCS }}}">Documentation</a>
               </div>
             </li>
             <li>
@@ -57,20 +103,28 @@
             </li>
             <li >
               <div id="issues" class="menuButton">
-                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="https://github.com/brownplt/pyret-lang/issues/new">Report an Issue</a>
+                <a class="focusable"
+                  aria-describedby="reportIssueInfo"
+                  role="treeitem" tabindex="-1" target="_blank" href="https://github.com/brownplt/pyret-lang/issues/new">Report an Issue</a>
               </div>
             </li>
             <li >
               <div id="discuss" class="menuButton">
-                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="https://groups.google.com/forum/#!forum/pyret-discuss">Discuss Pyret</a>
+                <a class="focusable"
+                  aria-describedby="discussPyretInfo"
+                  role="treeitem" tabindex="-1" target="_blank" href="https://groups.google.com/forum/#!forum/pyret-discuss">Discuss Pyret</a>
               </div>
             </li>
             <li >
               <div id="logging">
                 <span>
-                  <input class="focusable" role="treeitem" tabindex="-1" id="detailed-logging" type="checkbox" aria-pressed="false"
+                  <input class="focusable" role="treeitem" tabindex="-1" id="detailed-logging"
+                  aria-labelledby="detailed-logging-label"
+                  aria-describedby="detailedLoggingInfo"
+                  type="checkbox" aria-pressed="false"
                   aria-label="Contribute detailed usage information"/>
-                  <label for="detailed-logging">Contribute detailed usage information.</label>
+                  <label for="detailed-logging" id="detailed-logging-label>
+                    Contribute detailed usage information.</label>
                   <a href="https://www.pyret.org/cpo-faq#(part._logging)" target="_blank" rel="noopener noreferrer" class="focusable info-btn" role="treeitem" tabindex="-1"
                     id="detailed-logging-learn-more"
                     title="Learn More" aria-label="Learn More">?</a>
@@ -78,7 +132,9 @@
               </div>
             </li>
             <li >
-              <div id="logout" class="menuButton"><a  class="focusable" role="treeitem" tabindex="-1" href="/logout">Log out</a>
+              <div id="logout" class="menuButton">
+                <a class="focusable" aria-describedby="logoutInfo"
+                  role="treeitem" tabindex="-1" href="/logout">Log out</a>
               </div>
             </li>
           </ul>
@@ -86,7 +142,9 @@
 
         <li class="lhs topTier logoutOnly" id="connectButtonli">
           <div class="menu menuitemtitle">
-            <button role="treeitem" id="connectButton" class="logoutOnly focusable blueButton" tabindex="-1">Connect to Google Drive</button>
+            <button role="treeitem"
+              aria-describedby="connectButtonInfo"
+              id="connectButton" class="logoutOnly focusable blueButton" tabindex="-1">Connect to Google Drive</button>
           </div>
           <!--
             <div id="program-name-container" class="loginOnly">
@@ -102,6 +160,7 @@
               aria-haspopup="true"
               aria-expanded="false"
               aria-controls="filemenuContents"
+              aria-describedby="filemenuItemInfo"
               id="filemenuItem"
               tabindex="-1"
               class="focusable blueButton">
@@ -112,32 +171,52 @@
           <ul id="filemenuContents" class="menuContents" role="menu" aria-hidden="true"
             aria-label="File Menu">
             <li >
-              <div id="new" class="menuButton"><a class="focusable" role="treeitem" tabindex="-1" href="javascript:void(0)" >New</a></div>
+              <div id="new" class="menuButton">
+                <a class="focusable" role="treeitem" aria-label="New file"
+                  tabindex="-1" href="javascript:void(0)" >New</a></div>
             </li>
             <li>
-              <div id="open" class="menuButton"><a tabindex="-1" href="javascript:void(0)" class="focusable" role="treeitem" >Open</a></div>
+              <div id="open" class="menuButton">
+                <a tabindex="-1" href="javascript:void(0)" class="focusable"
+                  aria-label="Open file" role="treeitem" >Open</a></div>
             </li>
             <li >
-              <div id="open-original" class="menuButton disabled hidden"><a tabindex="-1" href="javascript:void(0)" class="focusable" role="treeitem">Open Original</a></div>
+              <div id="open-original" class="menuButton disabled hidden">
+                <a tabindex="-1" href="javascript:void(0)" class="focusable"
+                  aria-label="Open original file" role="treeitem">Open Original</a></div>
             </li>
             <li>
-              <div id="save" class="menuButton disabled"><a class="focusable disabled" role="treeitem" tabindex="-1" href="javascript:void(0)">Save</a></div>
-            </li>
-            <li >
-              <div id="saveas" class="menuButton"><a class="focusable" role="treeitem" tabindex="-1" href="javascript:void(0)">Save a copy</a></div>
-            </li>
-            <li>
-              <div id="download" class="menuButton"><a class="focusable" role="treeitem" tabindex="-1" href="javascript:void(0)">Download</a></div>
+              <div id="save" class="menuButton disabled">
+                <a class="focusable disabled" role="treeitem"
+                  aria-label="Save file"
+                  tabindex="-1" href="javascript:void(0)">Save</a></div>
             </li>
             <li>
-              <div id="rename" class="menuButton disabled"><a class="focusable disabled" role="treeitem" tabindex="-1" href="javascript:void(0)">Rename</a></div>
+              <div id="saveas" class="menuButton">
+                <a class="focusable" role="treeitem"
+                  aria-label="Save a copy"
+                  tabindex="-1" href="javascript:void(0)">Save a copy</a></div>
+            </li>
+            <li>
+              <div id="download" class="menuButton">
+                <a class="focusable" role="treeitem"
+                  aria-label="Download"
+                  tabindex="-1" href="javascript:void(0)">Download</a></div>
+            </li>
+            <li>
+              <div id="rename" class="menuButton disabled">
+                <a class="focusable disabled" role="treeitem"
+                  aria-label="Rename file"
+                  tabindex="-1" href="javascript:void(0)">Rename</a></div>
             </li>
           </ul>
         </li>
 
         <li class="loginOnly lhs topTier" id="insertli">
           <div id="insertPart" class="loginOnly menu menuitemtitle">
-            <button role="treeitem" aria-label="Insert, F11" id="insert" class="focusable blueButton loginOnly"  tabindex="-1">Insert</button>
+            <button role="treeitem"
+              aria-describedby="insertInfo"
+              aria-label="Insert, F11" id="insert" class="focusable blueButton loginOnly"  tabindex="-1">Insert</button>
           </div>
           <!-- <button id="saveButton" class="blueButton loginOnly">Save</button> -->
           <!-- <button id="openFile" class="blueButton loginOnly">Open</button> -->
@@ -149,7 +228,9 @@
 
         <li class="rhs topTier" disabled id="stopli">
           <div class="menu menuitemtitle">
-            <button role="treeitem" aria-label="Stop, F8" disabled id="breakButton" class="focusable blueButton rhs"  tabindex="-1">Stop</button>
+            <button role="treeitem" aria-label="Stop, F8" disabled id="breakButton"
+              aria-describedby="breakButtonInfo"
+              class="focusable blueButton rhs"  tabindex="-1">Stop</button>
           </div>
         </li>
 
@@ -162,6 +243,7 @@
                     aria-haspopup="true"
                     aria-expanded="false"
                     aria-controls="run-dropdown-content"
+                    aria-describedby="runDropdownInfo"
                     disabled
                     tabindex="-1">↴
             </button>
@@ -170,12 +252,15 @@
             aria-label="Run Options">
             <li id="select-run-old" role="menuitem">
               <div id="select-run" >
-                <a class="focusable" tabindex="-1" href="javascript:void(0)">Run</a>
+                <a class="focusable"
+                  aria-label="Run" tabindex="-1" href="javascript:void(0)">Run</a>
               </div>
             </li>
             <li id="select-tc-run-old" role="menuitem">
               <div id="select-tc-run" >
-                <a class="focusable" tabindex="-1" href="javascript:void(0)">Type-check and run<sup>(beta)</sup></a>
+                <a class="focusable"
+                  aria-label="Type-check and run"
+                  tabindex="-1" href="javascript:void(0)">Type-check and run<sup>(beta)</sup></a>
               </div>
             </li>
           </ul>
@@ -183,7 +268,9 @@
 
         <li class="rhs topTier" id="runli">
           <div id="runPart" class="blueButton rhs menuitemtitle" >
-            <button role="treeitem" aria-label="Run, F7" disabled id="runButton" class="focusable blueButton rhs" tabindex="-1">Run</button>
+            <button role="treeitem" aria-label="Run, F7" disabled id="runButton"
+              aria-describedby="runButtonInfo"
+              class="focusable blueButton rhs" tabindex="-1">Run</button>
           </div>
         </li>
       </ul>

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -19,14 +19,15 @@
   <div id="Toolbar" role="region" aria-label="Tool Controls" tabindex="-1">
     <nav aria-label="Toolbar" id="header">
       <h2 class="screenreader-only">Navigation Controls</h2>
-      <ul id="topTierUl" role="menubar" aria-label="Toolbar" tabindex="-1">
+      <ul id="topTierUl" role="tree" aria-label="Toolbar" tabindex="-1">
         <li class="lhs topTier" id="bonniemenuli">
           <div id="bonniemenu" class="menu menuitemtitle" style="float:none" >
-            <button role="menuitem" 
+            <button role="treeitem"
+                    id="bonniemenubutton"
                     aria-label="Main Menu"
                     aria-haspopup="true"
                     aria-expanded="false"
-                    aria-controls="bonniemenuContents" 
+                    aria-controls="bonniemenuContents"
                     tabindex="0"
                     class="blueButton focusable">
               <span>▾</span>
@@ -35,54 +36,57 @@
           </div>
           <ul id="bonniemenuContents" class="menuContents" role="menu" aria-hidden="true"
             aria-label="Main Menu">
-            <li role="menuitem">
+            <li >
               <div id="welcome" class="menuButton inert" style="text-align: center;">
                 <span>Welcome, <span id="username" style="display: inline; padding: 0px;">guest</span>!</span>
               </div>
             </li>
-            <li role="menuitem">
+            <li>
               <div id="drive-view" class="loginOnly menuButton">
-                <a class="focusable" tabindex="-1" target="_blank" href="/">My Programs</a>
+                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="/">My Programs</a>
               </div>
             </li>
-            <li role="menuitem">
+            <li >
               <div id="docs" class="menuButton">
-                <a class="focusable" tabindex="-1" target="_blank" href="http://pyret.org/docs/{{{ CURRENT_PYRET_DOCS }}}">Documentation</a>
+                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="http://pyret.org/docs/{{{ CURRENT_PYRET_DOCS }}}">Documentation</a>
               </div>
             </li>
-            <li role="menuitem">
+            <li>
               <div id="font"><div id="font-minus">-</div><div id="font-label">Font</div><div id="font-plus">+</div>
               </div>
             </li>
-            <li role="menuitem">
+            <li >
               <div id="issues" class="menuButton">
-                <a class="focusable" tabindex="-1" target="_blank" href="https://github.com/brownplt/pyret-lang/issues/new">Report an Issue</a>
+                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="https://github.com/brownplt/pyret-lang/issues/new">Report an Issue</a>
               </div>
             </li>
-            <li role="menuitem">
+            <li >
               <div id="discuss" class="menuButton">
-                <a class="focusable" tabindex="-1" target="_blank" href="https://groups.google.com/forum/#!forum/pyret-discuss">Discuss Pyret</a>
+                <a class="focusable" role="treeitem" tabindex="-1" target="_blank" href="https://groups.google.com/forum/#!forum/pyret-discuss">Discuss Pyret</a>
               </div>
             </li>
-            <li role="menuitem">
+            <li >
               <div id="logging">
                 <span>
-                  <input class="focusable" tabindex="-1" id="detailed-logging" type="checkbox"/>
+                  <input class="focusable" role="treeitem" tabindex="-1" id="detailed-logging" type="checkbox" aria-pressed="false"
+                  aria-label="Contribute detailed usage information"/>
                   <label for="detailed-logging">Contribute detailed usage information.</label>
-                  <a href="https://www.pyret.org/cpo-faq#(part._logging)" target="_blank" rel="noopener noreferrer" class="focusable info-btn" tabindex="-1" title="Learn More">?</a>
+                  <a href="https://www.pyret.org/cpo-faq#(part._logging)" target="_blank" rel="noopener noreferrer" class="focusable info-btn" role="treeitem" tabindex="-1"
+                    id="detailed-logging-learn-more"
+                    title="Learn More" aria-label="Learn More">?</a>
                 </span>
               </div>
             </li>
-            <li role="menuitem">
-              <div id="logout" class="menuButton"><a  class="focusable" tabindex="-1" href="/logout">Log out</a>
+            <li >
+              <div id="logout" class="menuButton"><a  class="focusable" role="treeitem" tabindex="-1" href="/logout">Log out</a>
               </div>
             </li>
           </ul>
         </li>
 
-        <li class="lhs topTier" id="connectButtonli">
+        <li class="lhs topTier logoutOnly" id="connectButtonli">
           <div class="menu menuitemtitle">
-            <button role="menuitem" id="connectButton"  class="logoutOnly focusable blueButton" tabindex="-1">Connect to Google Drive</button>
+            <button role="treeitem" id="connectButton" class="logoutOnly focusable blueButton" tabindex="-1">Connect to Google Drive</button>
           </div>
           <!--
             <div id="program-name-container" class="loginOnly">
@@ -93,12 +97,12 @@
 
         <li class="loginOnly lhs topTier" id="filemenuli">
           <div id="filemenu" class="loginOnly menu menuitemtitle" style="float:none" >
-            <button role="menuitem"
-              aria-label="File" 
+            <button role="treeitem"
+              aria-label="File"
               aria-haspopup="true"
               aria-expanded="false"
               aria-controls="filemenuContents"
-              id="filemenuItem" 
+              id="filemenuItem"
               tabindex="-1"
               class="focusable blueButton">
               <span>▾ File</span><span id="filename"></span>
@@ -107,57 +111,58 @@
           <!-- div id="filemenuContents" class="menuContents" style="display: none; z-index: 8990;" -->
           <ul id="filemenuContents" class="menuContents" role="menu" aria-hidden="true"
             aria-label="File Menu">
-            <li>
-              <div id="new" class="menuButton"><a class="focusable" tabindex="-1" href="javascript:void(0)" >New</a></div>
+            <li >
+              <div id="new" class="menuButton"><a class="focusable" role="treeitem" tabindex="-1" href="javascript:void(0)" >New</a></div>
             </li>
             <li>
-              <div id="open" class="menuButton"><a tabindex="-1" href="javascript:void(0)" class="focusable" >Open</a></div>
+              <div id="open" class="menuButton"><a tabindex="-1" href="javascript:void(0)" class="focusable" role="treeitem" >Open</a></div>
+            </li>
+            <li >
+              <div id="open-original" class="menuButton disabled hidden"><a tabindex="-1" href="javascript:void(0)" class="focusable" role="treeitem">Open Original</a></div>
             </li>
             <li>
-              <div id="open-original" class="menuButton disabled hidden"><a tabindex="-1" href="javascript:void(0)" class="focusable">Open Original</a></div>
+              <div id="save" class="menuButton disabled"><a class="focusable disabled" role="treeitem" tabindex="-1" href="javascript:void(0)">Save</a></div>
+            </li>
+            <li >
+              <div id="saveas" class="menuButton"><a class="focusable" role="treeitem" tabindex="-1" href="javascript:void(0)">Save a copy</a></div>
             </li>
             <li>
-              <div id="save" class="menuButton disabled"><a class="focusable disabled" tabindex="-1" href="javascript:void(0)">Save</a></div>
+              <div id="download" class="menuButton"><a class="focusable" role="treeitem" tabindex="-1" href="javascript:void(0)">Download</a></div>
             </li>
             <li>
-              <div id="saveas" class="menuButton"><a class="focusable" tabindex="-1" href="javascript:void(0)">Save a copy</a></div>
-            </li>
-            <li>
-              <div id="download" class="menuButton"><a class="focusable" tabindex="-1" href="javascript:void(0)">Download</a></div>
-            </li>
-            <li>
-              <div id="rename" class="menuButton disabled"><a class="focusable disabled" tabindex="-1" href="javascript:void(0)">Rename</a></div>
+              <div id="rename" class="menuButton disabled"><a class="focusable disabled" role="treeitem" tabindex="-1" href="javascript:void(0)">Rename</a></div>
             </li>
           </ul>
         </li>
 
-        <li class="lhs topTier" id="insertli">
+        <li class="loginOnly lhs topTier" id="insertli">
           <div id="insertPart" class="loginOnly menu menuitemtitle">
-            <button role="button" aria-label="Insert, F11" id="insert" class="focusable blueButton loginOnly"  tabindex="-1">Insert</button>
+            <button role="treeitem" aria-label="Insert, F11" id="insert" class="focusable blueButton loginOnly"  tabindex="-1">Insert</button>
           </div>
           <!-- <button id="saveButton" class="blueButton loginOnly">Save</button> -->
           <!-- <button id="openFile" class="blueButton loginOnly">Open</button> -->
         </li>
-        <li class="lhs topTier" id="publishli">
+
+        <li class="lhs topTier" id="publishli" style="display: none;">
           <div id="shareContainer" class="menu menuitemtitle"></div>
         </li>
 
-        <li class="rhs topTier" id="stopli">
+        <li class="rhs topTier" disabled id="stopli">
           <div class="menu menuitemtitle">
-            <button role="button" aria-label="Stop, F8" disabled id="breakButton" class="focusable blueButton rhs"  tabindex="-1">Stop</button>
+            <button role="treeitem" aria-label="Stop, F8" disabled id="breakButton" class="focusable blueButton rhs"  tabindex="-1">Stop</button>
           </div>
         </li>
 
         <li class="rhs topTier" id="rundropdownli">
           <div class="menu rhs menuitemtitle" style="float:none">
-            <button role="menuitem"
+            <button role="treeitem"
                     id="runDropdown"
                     class="focusable blueButton dropdown rhs"
                     aria-label="Run Options"
                     aria-haspopup="true"
                     aria-expanded="false"
                     aria-controls="run-dropdown-content"
-                    disabled 
+                    disabled
                     tabindex="-1">↴
             </button>
           </div>
@@ -178,7 +183,7 @@
 
         <li class="rhs topTier" id="runli">
           <div id="runPart" class="blueButton rhs menuitemtitle" >
-            <button role="menuitem" aria-label="Run, F7" disabled id="runButton" class="focusable blueButton rhs" tabindex="-1">Run</button>
+            <button role="treeitem" aria-label="Run, F7" disabled id="runButton" class="focusable blueButton rhs" tabindex="-1">Run</button>
           </div>
         </li>
       </ul>

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -161,16 +161,15 @@
                     tabindex="-1">↴
             </button>
           </div>
-
-          <ul id="run-dropdown-content" class="menuContents" role="menu" aria-hidden="true"
+          <ul id="run-dropdown-content" role="menu" aria-hidden="true"
             aria-label="Run Options">
             <li id="select-run-old" role="menuitem">
-              <div id="select-run" class="menuButton">
+              <div id="select-run" >
                 <a class="focusable" tabindex="-1" href="javascript:void(0)">Run</a>
               </div>
             </li>
             <li id="select-tc-run-old" role="menuitem">
-              <div id="select-tc-run" class="menuButton">
+              <div id="select-tc-run" >
                 <a class="focusable" tabindex="-1" href="javascript:void(0)">Type-check and run<sup>(beta)</sup></a>
               </div>
             </li>

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -893,7 +893,7 @@ $(function() {
       //$(this).closest('nav').closest('main').focus();
     } else if (e.keyCode === 32) {
       //console.log('clicked space on', $(this));
-      $(this)[0].click();
+      //$(this)[0].click();
       e.stopPropagation();
     } else if (e.keyCode === 13) {
       //console.log('enter pressed');

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -370,6 +370,24 @@ $(function() {
     });
   }
 
+  function say(msg, forget) {
+    if (msg === "") return;
+    var announcements = document.getElementById("announcementlist");
+    var li = document.createElement("LI");
+    li.appendChild(document.createTextNode(msg));
+    announcements.insertBefore(li, announcements.firstChild);
+    if (forget) {
+      setTimeout(function() {
+        announcements.removeChild(li);
+      }, 1000);
+    }
+  }
+
+  function sayAndForget(msg) {
+    //console.log('doing sayAndForget', msg);
+    say(msg, true);
+  }
+
   function cycleAdvance(currIndex, maxIndex, reverseP) {
     var nextIndex = currIndex + (reverseP? -1 : +1);
     nextIndex = ((nextIndex % maxIndex) + maxIndex) % maxIndex;
@@ -1137,5 +1155,7 @@ $(function() {
   CPO.showShareContainer = showShareContainer;
   CPO.loadProgram = loadProgram;
   CPO.cycleFocus = cycleFocus;
+  CPO.say = say;
+  CPO.sayAndForget = sayAndForget;
 
 });

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -25,6 +25,7 @@ window.clearFlash = function() {
   $(".notificationArea").empty();
 }
 window.stickError = function(message, more) {
+  CPO.sayAndForget(message);
   clearFlash();
   var err = $("<div>").addClass("error").text(message);
   if(more) {
@@ -34,18 +35,21 @@ window.stickError = function(message, more) {
   $(".notificationArea").prepend(err);
 };
 window.flashError = function(message) {
+  CPO.sayAndForget(message);
   clearFlash();
   var err = $("<div>").addClass("error").text(message);
   $(".notificationArea").prepend(err);
   err.fadeOut(7000);
 };
 window.flashMessage = function(message) {
+  CPO.sayAndForget(message);
   clearFlash();
   var msg = $("<div>").addClass("active").text(message);
   $(".notificationArea").prepend(msg);
   msg.fadeOut(7000);
 };
 window.stickMessage = function(message) {
+  CPO.sayAndForget(message);
   clearFlash();
   var err = $("<div>").addClass("active").text(message);
   $(".notificationArea").prepend(err);

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -59,7 +59,7 @@
 
     var replContainer = $("<div>").addClass("repl");
     replContainer.attr("tabindex", "-1");
-    replContainer.attr("aria-hidden", "true");
+    //replContainer.attr("aria-hidden", "true");
     $("#REPL").append(replContainer);
 
     var logDetailedOption = $("#detailed-logging");

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -534,9 +534,27 @@
         e.preventDefault();
       });
 
+      function reciteHelp() {
+        CPO.sayAndForget(
+          "Press Escape to exit help. " +
+          "Control question mark: recite help. " +
+          "Control s: save. " +
+          "Control enter: run the code in the definitions window. " +
+          "Control left: move cursor left by one word. " +
+          "Control right: move cursor right by one word. " +
+          "Alt left: if cursor is just before a right parenthesis or end keyword, " +
+          "move left to matching delimiter, " +
+          "otherwise move left by one word. " +
+          "Alt right: like alt left, but move right. " +
+          "Escape left: synonym for alt left, in case alt key is used by browser. " +
+          "Escape right: synonym for alt right."
+        );
+      }
+
       // pull up help menu
       Mousetrap.bindGlobal('ctrl+shift+/', function(e) {
         $("#help-keys").fadeIn(100);
+        reciteHelp();
         e.stopImmediatePropagation();
         e.preventDefault();
       });

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -77,6 +77,7 @@
 
     localSettings.change("log-detailed", function(_, newValue) {
       logDetailedOption[0].checked = newValue == 'true';
+      logDetailedOption.attr('aria-pressed', '' + (newValue == 'true'));
     });
 
     runtime.setParam("imgUrlProxy", function(s) {

--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -585,6 +585,7 @@
       });
 
       var breakButton = options.breakButton;
+      var stopLi = $('#stopli');
       container.append(output).append(promptContainer);
 
       var img = $("<img>").attr({
@@ -645,6 +646,7 @@
           options.runButton.append(runContents);
           options.runButton.attr("disabled", false);
           breakButton.attr("disabled", true);
+          stopLi.attr('disabled', true);
           canShowRunningIndicator = false;
           if(cm) {
             cm.setValue("");
@@ -665,6 +667,7 @@
          if(canShowRunningIndicator) {
             options.runButton.attr("disabled", true);
             breakButton.attr("disabled", false);
+            stopLi.attr('disabled', false);
             options.runButton.empty();
             var text = $("<span>").text("Running...");
             text.css({
@@ -914,6 +917,7 @@
 
       var onBreak = function() {
         breakButton.attr("disabled", true);
+        stopLi.attr('disabled', true);
         repl.stop();
         closeAnimationIfOpen();
         Jsworld.shutdown({ cleanShutdown: true });
@@ -921,6 +925,7 @@
       };
 
       breakButton.attr("disabled", true);
+      stopLi.attr('disabled', true);
       breakButton.click(onBreak);
 
       return {

--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -245,8 +245,13 @@
         }
         if (pointer < items.length - 1) {
           pointer++;
-          loadItem();
-          CM.refresh();
+          if (pointer === (items.length - 1) &&
+              items[pointer].code === 'def//') {
+            pointer--;
+          } else {
+            loadItem();
+            CM.refresh();
+          }
         }
       }
       function nextItem() {

--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -890,6 +890,7 @@
           extraKeys: CodeMirror.normalizeKeyMap({
             'Enter': function(cm) { runner(cm.getValue(), {cm: cm}); },
             'Shift-Enter': "newlineAndIndent",
+            'Tab': 'indentAuto',
             'Up': prevItem,
             'Down': nextItem,
             'Ctrl-Up': "goLineUp",

--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -268,24 +268,6 @@
 
       // a11y stuff
 
-      function say(msg, forget) {
-        if (msg === "") return;
-        var announcements = document.getElementById("announcementlist");
-        var li = document.createElement("LI");
-        li.appendChild(document.createTextNode(msg));
-        announcements.insertBefore(li, announcements.firstChild);
-        if (forget) {
-          setTimeout(function() {
-            announcements.removeChild(li);
-          }, 1000);
-        }
-      }
-
-      function sayAndForget(msg) {
-        //console.log('doing sayAndForget', msg);
-        say(msg, true);
-      }
-
       function outputText(elt) {
         //console.log('outputText of', elt);
         var text;
@@ -364,7 +346,7 @@
             }
           }
         }
-        sayAndForget(recital);
+        CPO.sayAndForget(recital);
         return true;
       }
 
@@ -373,7 +355,7 @@
         var ln = pos.line; var ch = pos.ch;
         var char = cm.getRange({line: ln, ch: ch}, {line: ln, ch: ch+1});
         if (char === " ") char = "space";
-        sayAndForget(char);
+        CPO.sayAndForget(char);
       }
 
 

--- a/src/web/js/share.js
+++ b/src/web/js/share.js
@@ -62,7 +62,7 @@ window.makeShareAPI = function makeShareAPI(pyretVersion) {
   $(".menuButton a").click(hideAllHovers);
 
   function makeShareLink(originalFile) {
-    var link = $('<button aria-label="Publish, F9" class="focusable blueButton" role="treeitem" tabindex="-1">').text("Publish");
+    var link = $('<button aria-label="Publish, F9" aria-describedby="publishInfo" class="focusable blueButton" role="treeitem" tabindex="-1">').text("Publish");
     var shareDiv = $("<div>").addClass("share");
     link.click(function() { showShares(shareDiv, originalFile); });
     return link;

--- a/src/web/js/share.js
+++ b/src/web/js/share.js
@@ -62,7 +62,7 @@ window.makeShareAPI = function makeShareAPI(pyretVersion) {
   $(".menuButton a").click(hideAllHovers);
 
   function makeShareLink(originalFile) {
-    var link = $('<button aria-label="Publish, F9" class="focusable blueButton" role="button" tabindex="-1">').text("Publish");
+    var link = $('<button aria-label="Publish, F9" class="focusable blueButton" role="treeitem" tabindex="-1">').text("Publish");
     var shareDiv = $("<div>").addClass("share");
     link.click(function() { showShares(shareDiv, originalFile); });
     return link;


### PR DESCRIPTION
The downarrow box is thinner, and the submenu it spawns becomes wide and goes under the Run button. Everything is white-on-blue to match the Run button. This should near-perfectly match how things were in `horizon` before a11y was added.

Addresses the Run menu part (item no. 2) of Issue #274.