### PR TITLE
Some a11y ARIA enhancements

### DIFF
--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -3,147 +3,123 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>code.pyret.org</title>
-  <link rel="stylesheet" href="/css/reset.css"></link>
+  <link rel="stylesheet" href="/css/reset.css" />
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
-  <link rel="stylesheet" href="/css/codemirror.css"></link>
-  <link rel="stylesheet" href="/css/foldgutter.css"></link>
-  <link rel="stylesheet" href="/css/shared.css"></link>
-  <link rel="stylesheet" href="/css/editor.css"></link>
-  <link rel="stylesheet" href="/css/font-awesome.min.path-fixed.css"></link>
-  <link rel="icon" type="image/png" href="/img/pyret-icon.png">
+  <link rel="stylesheet" href="/css/codemirror.css" />
+  <link rel="stylesheet" href="/css/foldgutter.css" />
+  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/editor.css" />
+  <link rel="stylesheet" href="/css/font-awesome.min.path-fixed.css" />
+  <link rel="icon" type="image/png" href="/img/pyret-icon.png" />
   <style id="highlight-styles"></style>
   <script>var APP_LOG_URL = "{{{ LOG_URL }}}";</script>
 </head>
 <body>
   <main>
-  <div id="Toolbar" role="region" aria-label="Tool Controls" tabindex="-1">
-    <nav aria-label="Toolbar" id="header">
-      <h2 class="screenreader-only">Navigation Controls
-        <div class="screenreader-only">
-          <p class="screenreader-only" id="bonniemenubuttonInfo">Main submenu.
-          Use up and down arrows to navigate this submenu.
-          Click, enter, or space to choose a submenu item.
-          Use left and right arrows to go to adjacent menu items.
-          Press Control question mark for Help.</p>
-          <p class="screenreader-only" id="connectButtonInfo">Connect button.
-          Click, enter, or space to connect to Google Drive.
-          Use left and right arrows to go to adjacent menu items.</p>
-          <p class="screenreader-only" id="filemenuItemInfo">File submenu.
-          Use up and down arrows to navigate this submenu.
-          Click, enter, or space to choose a submenu item.
-          Use left and right arrows to go to adjacent menu items.</p>
-          <p class="screenreader-only" id="insertInfo">Insert button.
-          Click, enter, or space to open Insert dialog.
-          Keyboard shortcut: F11.
-          Use left and right arrows to go to adjacent menu items.</p>
-          <p class="screenreader-only" id="publishInfo">Share button.
-          Click, enter, or space to open publish dialog.
-          Use left and right arrows to go to adjacent menu items.</p>
-          <p class="screenreader-only" id="breakButtonInfo">Stop button.
-          Click, enter, or space to stop currently running program.
-          Use left and right arrows to go to adjacent menu items.</p>
-          <p class="screenreader-only" id="runDropdownInfo">Run options dropdown submenu.
-          Use up and down arrows to navigate this submenu.
-          Use left and right arrows to go to adjacent menu items.
-          Click, enter, or space to choose an option.</p>
-          <p class="screenreader-only" id="runButtonInfo">Run button.
-          Click, enter, or space to run current definitions window.
-          Keyboard shortcut: F7.
-          Use left and right arrows to go to adjacent menu items.</p>
-        </div>
-      </h2>
-      <ul id="topTierUl" role="tree" aria-label="Toolbar" tabindex="-1">
-        <li class="lhs topTier" id="bonniemenuli">
+  <div id="Toolbar" class="toolbarregion" role="region" aria-label="Tool Controls" tabindex="-1">
+    <nav aria-label="Toolbar" role="menubar" id="header">
+      <h2 id="menutitle" class="screenreader-only">Navigation Controls</h2>
+      <p class="screenreader-only" id="mhelp">
+      <span id="mhelp-intro">The toolbar menu has at most two levels, with some top-level
+        menu items having a submenu.</span>
+      <span id="mhelp-menus">Use left and right arrows to navigate across the top-level menu items.
+      </span>
+      <span id="mhelp-submenu">Use up and down arrows to explore within a submenu.
+      </span>
+      <span id="mhelp-activate">Use Enter, Space, or Click to activate.</span>
+      <span id="mhelp-escape-submenu">Use left and right arrows to exit submenu and go to an
+        adjacent top-level menu item.</span>
+      <span id="mhelp-escape">Use Escape, Tab, F6 or Shift-F6 to exit these menus altogether.</span>
+      </p>
+      <ul id="topTierUl" role="menu" aria-labelledby="menutitle"
+        aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
+        aria-label="Toolbar" tabindex="-1">
+        <li role="presentation"
+          class="lhs topTier" id="bonniemenuli">
           <div id="bonniemenu" class="menu menuitemtitle" style="float:none" >
-            <button role="treeitem"
+            <button role="menuitem"
                     id="bonniemenubutton"
                     aria-label="Main Menu"
+                    aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
                     aria-haspopup="true"
                     aria-expanded="false"
                     aria-controls="bonniemenuContents"
-                    aria-describedby="bonniemenubuttonInfo"
+                    aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
                     tabindex="-1"
                     class="blueButton focusable">
               <span>▾</span>
               <img class="logo" src="/img/pyret-logo.png"></img>
             </button>
           </div>
-          <div class="screenreader-only">
-            <p class="screenreader-only myProgramsInfo">My Programs</p>
-            <p class="screenreader-only documentationInfo">Documentation</p>
-            <p class="screenreader-only reportIssueInfo">Report an issue</p>
-            <p class="screenreader-only discussPyretInfo">Discuss Pyret</p>
-            <p class="screenreader-only detailedLoggingInfo">Contrinute detailed usage information</p>
-            <p class="screenreader-only logoutInfo">Log out</p>
-          </div>
-          <ul id="bonniemenuContents" class="menuContents" role="menu" aria-hidden="true"
+          <ul id="bonniemenuContents" class="menuContents submenu" role="menu" aria-hidden="true"
             aria-label="Main Menu">
-            <li >
+            <li role="presentation">
               <div id="welcome" class="menuButton inert" style="text-align: center;">
                 <span>Welcome, <span id="username" style="display: inline; padding: 0px;">guest</span>!</span>
               </div>
             </li>
-            <li>
+            <li role="presentation">
               <div id="drive-view" class="loginOnly menuButton">
-                <a class="focusable"
-                  aria-describedby="myProgramsInfo" role="treeitem" tabindex="-1" target="_blank" href="/">
+                <a class="focusable" role="menuitem"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  tabindex="-1" target="_blank" href="/">
                   My Programs</a>
               </div>
             </li>
-            <li >
+            <li role="presentation">
               <div id="docs" class="menuButton">
-                <a class="focusable"
-                  aria-describedby="documentationInfo"
-                  role="treeitem" tabindex="-1" target="_blank" href="http://pyret.org/docs/{{{ CURRENT_PYRET_DOCS }}}">Documentation</a>
+                <a class="focusable" role="menuitem"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  tabindex="-1" target="_blank" href="http://pyret.org/docs/{{{ CURRENT_PYRET_DOCS }}}">Documentation</a>
               </div>
             </li>
-            <li>
+            <li role="presentation">
               <div id="font"><div id="font-minus">-</div><div id="font-label">Font</div><div id="font-plus">+</div>
               </div>
             </li>
-            <li >
+            <li role="presentation">
               <div id="issues" class="menuButton">
-                <a class="focusable"
-                  aria-describedby="reportIssueInfo"
-                  role="treeitem" tabindex="-1" target="_blank" href="https://github.com/brownplt/pyret-lang/issues/new">Report an Issue</a>
+                <a class="focusable" role="menuitem"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  tabindex="-1" target="_blank" href="https://github.com/brownplt/pyret-lang/issues/new">Report an Issue</a>
               </div>
             </li>
-            <li >
+            <li role="presentation">
               <div id="discuss" class="menuButton">
-                <a class="focusable"
-                  aria-describedby="discussPyretInfo"
-                  role="treeitem" tabindex="-1" target="_blank" href="https://groups.google.com/forum/#!forum/pyret-discuss">Discuss Pyret</a>
+                <a class="focusable" role="menuitem"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  tabindex="-1" target="_blank" href="https://groups.google.com/forum/#!forum/pyret-discuss">Discuss Pyret</a>
               </div>
             </li>
-            <li >
+            <li role="presentation">
               <div id="logging" class="menuButton">
                 <span>
-                  <input class="focusable" role="treeitem" tabindex="-1" id="detailed-logging"
+                  <input class="focusable" role="menuitem" tabindex="-1" id="detailed-logging"
                   aria-labelledby="detailed-logging-label"
-                  aria-describedby="detailedLoggingInfo"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
                   type="checkbox" aria-pressed="false"
                   aria-label="Contribute detailed usage information"/>
                   <label for="detailed-logging" id="detailed-logging-label">
                     Contribute detailed usage information.</label>
-                  <a href="https://www.pyret.org/cpo-faq#(part._logging)" target="_blank" rel="noopener noreferrer" class="focusable info-btn" role="treeitem" tabindex="-1"
+                  <a href="https://www.pyret.org/cpo-faq#(part._logging)" target="_blank" rel="noopener noreferrer" class="focusable info-btn" role="menuitem" tabindex="-1"
                     id="detailed-logging-learn-more"
                     title="Learn More" aria-label="Learn More">?</a>
                 </span>
               </div>
             </li>
-            <li >
+            <li role="presentation">
               <div id="logout" class="menuButton">
-                <a class="focusable" aria-describedby="logoutInfo"
-                  role="treeitem" tabindex="-1" href="/logout">Log out</a>
+                <a class="focusable" aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  role="menuitem" tabindex="-1" href="/logout">Log out</a>
               </div>
             </li>
           </ul>
         </li>
 
-        <li class="lhs topTier logoutOnly" id="connectButtonli">
+        <li role="presentation" class="lhs topTier logoutOnly" id="connectButtonli">
           <div class="menu menuitemtitle">
-            <button role="treeitem"
-              aria-describedby="connectButtonInfo"
+            <button role="menuitem"
+              aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
               id="connectButton" class="logoutOnly focusable blueButton" tabindex="-1">Connect to Google Drive</button>
           </div>
           <!--
@@ -153,14 +129,14 @@
           -->
         </li>
 
-        <li class="loginOnly lhs topTier" id="filemenuli">
+        <li role="presentation" class="loginOnly lhs topTier" id="filemenuli">
           <div id="filemenu" class="loginOnly menu menuitemtitle" style="float:none" >
-            <button role="treeitem"
+            <button role="menuitem"
               aria-label="File"
               aria-haspopup="true"
               aria-expanded="false"
               aria-controls="filemenuContents"
-              aria-describedby="filemenuItemInfo"
+              aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
               id="filemenuItem"
               tabindex="-1"
               class="focusable blueButton">
@@ -168,108 +144,116 @@
             </button>
           </div>
           <!-- div id="filemenuContents" class="menuContents" style="display: none; z-index: 8990;" -->
-          <ul id="filemenuContents" class="menuContents" role="menu" aria-hidden="true"
+          <ul id="filemenuContents" class="menuContents submenu" role="menu" aria-hidden="true"
             aria-label="File Menu">
-            <li >
+            <li role="presentation">
               <div id="new" class="menuButton">
-                <a class="focusable" role="treeitem" aria-label="New file"
+                <a class="focusable" role="menuitem" aria-label="New file"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
                   tabindex="-1" href="javascript:void(0)" >New</a></div>
             </li>
-            <li>
+            <li role="presentation">
               <div id="open" class="menuButton">
-                <a tabindex="-1" href="javascript:void(0)" class="focusable"
-                  aria-label="Open file" role="treeitem" >Open</a></div>
+                <a  class="focusable" role="menuitem" aria-label="Open file"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  tabindex="-1" href="javascript:void(0)">Open</a></div>
             </li>
-            <li >
+            <li role="presentation">
               <div id="open-original" class="menuButton disabled hidden">
-                <a tabindex="-1" href="javascript:void(0)" class="focusable"
-                  aria-label="Open original file" role="treeitem">Open Original</a></div>
+                <a class="focusable" role="menuitem" aria-label="Open original file"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  tabindex="-1" href="javascript:void(0)">Open Original</a></div>
             </li>
-            <li>
+            <li role="presentation">
               <div id="save" class="menuButton disabled">
-                <a class="focusable disabled" role="treeitem"
-                  aria-label="Save file"
+                <a class="focusable disabled" role="menuitem" aria-label="Save file"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
                   tabindex="-1" href="javascript:void(0)">Save</a></div>
             </li>
-            <li>
+            <li role="presentation">
               <div id="saveas" class="menuButton">
-                <a class="focusable" role="treeitem"
-                  aria-label="Save a copy"
+                <a class="focusable" role="menuitem" aria-label="Save a copy"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
                   tabindex="-1" href="javascript:void(0)">Save a copy</a></div>
             </li>
-            <li>
+            <li role="presentation">
               <div id="download" class="menuButton">
-                <a class="focusable" role="treeitem"
-                  aria-label="Download"
+                <a class="focusable" role="menuitem" aria-label="Download"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
                   tabindex="-1" href="javascript:void(0)">Download</a></div>
             </li>
-            <li>
+            <li role="presentation">
               <div id="rename" class="menuButton disabled">
-                <a class="focusable disabled" role="treeitem"
-                  aria-label="Rename file"
+                <a class="focusable disabled" role="menuitem" aria-label="Rename file"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
                   tabindex="-1" href="javascript:void(0)">Rename</a></div>
             </li>
           </ul>
         </li>
 
-        <li class="loginOnly lhs topTier" id="insertli">
+        <li role="presentation" class="loginOnly lhs topTier" id="insertli">
           <div id="insertPart" class="loginOnly menu menuitemtitle">
-            <button role="treeitem"
-              aria-describedby="insertInfo"
+            <button role="menuitem"
+              aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
               aria-label="Insert, F11" id="insert" class="focusable blueButton loginOnly"  tabindex="-1">Insert</button>
           </div>
           <!-- <button id="saveButton" class="blueButton loginOnly">Save</button> -->
           <!-- <button id="openFile" class="blueButton loginOnly">Open</button> -->
         </li>
 
-        <li class="lhs topTier" id="publishli" style="display: none;">
+        <li role="presentation" class="lhs topTier" id="publishli" style="display: none;">
           <div id="shareContainer" class="menu menuitemtitle"></div>
         </li>
 
-        <li class="rhs topTier" disabled id="stopli">
+        <li role="presentation" class="rhs topTier" disabled id="stopli">
           <div class="menu menuitemtitle">
-            <button role="treeitem" aria-label="Stop, F8" disabled id="breakButton"
-              aria-describedby="breakButtonInfo"
+            <button role="menuitem" aria-label="Stop, F8" disabled id="breakButton"
+              aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
               class="focusable blueButton rhs"  tabindex="-1">Stop</button>
           </div>
         </li>
 
-        <li class="rhs topTier" id="rundropdownli">
+        <li role="presentation" class="rhs topTier" id="rundropdownli">
           <div class="menu rhs menuitemtitle" style="float:none">
-            <button role="treeitem"
+            <button role="menuitem"
                     id="runDropdown"
                     class="focusable blueButton dropdown rhs"
                     aria-label="Run Options"
                     aria-haspopup="true"
                     aria-expanded="false"
                     aria-controls="run-dropdown-content"
-                    aria-describedby="runDropdownInfo"
+                    aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
                     disabled
                     tabindex="-1">↴
             </button>
           </div>
-          <ul id="run-dropdown-content" role="menu" aria-hidden="true"
+          <ul id="run-dropdown-content" class="submenu" role="menu" aria-hidden="true"
             aria-label="Run Options">
-            <li id="select-run-old" role="menuitem">
+            <li id="select-run-old" >
               <div id="select-run" >
                 <a class="focusable"
-                  aria-label="Run" tabindex="-1" href="javascript:void(0)">Run</a>
+                  role="menuitem"
+                  aria-label="Run" aria-setsize="2" aria-posinset="1"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  tabindex="-1" href="javascript:void(0)">Run</a>
               </div>
             </li>
-            <li id="select-tc-run-old" role="menuitem">
+            <li id="select-tc-run-old">
               <div id="select-tc-run" >
                 <a class="focusable"
-                  aria-label="Type-check and run"
+                  role="menuitem"
+                  aria-label="Type-check and run" aria-setsize="2" aria-posinset="2"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
                   tabindex="-1" href="javascript:void(0)">Type-check and run<sup>(beta)</sup></a>
               </div>
             </li>
           </ul>
         </li>
 
-        <li class="rhs topTier" id="runli">
+        <li role="presentation" class="rhs topTier" id="runli">
           <div id="runPart" class="blueButton rhs menuitemtitle" >
-            <button role="treeitem" aria-label="Run, F7" disabled id="runButton"
-              aria-describedby="runButtonInfo"
+            <button role="menuitem" aria-label="Run, F7" disabled id="runButton"
+              aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
               class="focusable blueButton rhs" tabindex="-1">Run</button>
           </div>
         </li>
@@ -289,8 +273,8 @@
     <div class="modal-body">
     </div>
     <div class="modal-footer">
-      <button class="submit blueButton">Submit</span>
-      <button class="close blueButton">Close</span>
+      <button class="submit blueButton">Submit</button>
+      <button class="close blueButton">Close</button>
     </div>
   </div>
 </div>

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -206,6 +206,8 @@ $(function() {
       CM.display.wrapper.appendChild(mkWarningLower()[0]);
     }
 
+    getTopTierMenuitems();
+
     return {
       cm: CM,
       refresh: function() { CM.refresh(); },
@@ -408,10 +410,11 @@ $(function() {
     var fc = editor.focusCarousel;
     var docmain = document.getElementById("main");
     if (!fc[0]) {
-      //var toolbar = document.getElementById('Toolbar');
-      //fc[0] = toolbar;
+      var toolbar = document.getElementById('Toolbar');
+      fc[0] = toolbar;
       //fc[0] = document.getElementById("headeronelegend");
-      fc[0] = document.getElementById('bonniemenubutton');
+      //getTopTierMenuitems();
+      //fc[0] = document.getElementById('bonniemenubutton');
     }
     if (!fc[1]) {
       var docreplMain = docmain.getElementsByClassName("replMain");
@@ -441,6 +444,7 @@ $(function() {
   }
 
   function cycleFocus(reverseP) {
+    //console.log('doing cycleFocus', reverseP);
     var editor = this.editor;
     var fCarousel = editor.focusCarousel;
     populateFocusCarousel(editor);
@@ -462,7 +466,10 @@ $(function() {
     } while (!focusElt);
 
     var focusElt0;
-    if (focusElt.classList.contains("replMain") ||
+    if (focusElt.classList.contains('toolbarregion')) {
+      getTopTierMenuitems();
+      focusElt0 = document.getElementById('bonniemenubutton');
+    } else if (focusElt.classList.contains("replMain") ||
       focusElt.classList.contains("CodeMirror")) {
       var textareas = focusElt.getElementsByTagName("textarea");
       if (textareas.length === 0) {
@@ -670,6 +677,7 @@ $(function() {
   var theToolbar = $(document).find('#Toolbar');
 
   function getTopTierMenuitems() {
+    //console.log('doing getTopTierMenuitems')
     var topTierMenuitems = $(document).find('nav[aria-label=Toolbar] ul li.topTier').toArray();
     var lastElt = topTierMenuitems.pop();
     var iiLastElt = topTierMenuitems.pop();
@@ -691,7 +699,7 @@ $(function() {
   }
 
   function insertAriaPos(submenu) {
-    //console.log('submenu=', submenu);
+    //console.log('doing insertAriaPos', submenu)
     var arr = submenu.toArray();
     //console.log('arr=', arr);
     var len = arr.length;
@@ -716,15 +724,15 @@ $(function() {
     //most any key at all
     var kc = e.keyCode;
     //console.log('toolbar keydown', e.keyCode);
-    if (e.obskeyCode === 9 || kc === 27) {
-      //console.log('toolbar keydown: 1st br');
+    if (kc === 9 || kc === 27) {
+      // escape
       hideAllTopMenuitems();
       //console.log('calling cycleFocus')
       CPO.cycleFocus();
       e.stopPropagation();
     } else if (kc === 37 || kc === 38 || kc === 39 || kc === 40) {
-      //console.log('toolbar keydown: 2nd br');
-      var target = $(this).find('[tabIndex=0]');
+      // an arrow
+      var target = $(this).find('[tabIndex=-1]');
       getTopTierMenuitems();
       /*
       //console.log('target=', target);
@@ -733,6 +741,7 @@ $(function() {
       //console.log('topTierLi=', topTierLi.length);
       if (topTierLi.length === 0) {
         topTierLi = $('#bonniemenuli')
+        // go straight here?
         target = topTierLi.find('.focusable').first();
       }
       switchTopMenuitem(topTierLi.closest('ul[id=topTierUl]'), topTierLi, target);
@@ -761,11 +770,11 @@ $(function() {
     if (!submenuOpen) {
       //console.log('hiddenp true branch');
       hideAllTopMenuitems();
-      thisTopMenuitem.children('ul[role=menu]').attr('aria-hidden', 'false').show();
+      thisTopMenuitem.children('ul.submenu').attr('aria-hidden', 'false').show();
       thisTopMenuitem.children().first().find('[aria-expanded]').attr('aria-expanded', 'true');
     } else {
       //console.log('hiddenp false branch');
-      thisTopMenuitem.children('ul[role=menu]').attr('aria-hidden', 'true').hide();
+      thisTopMenuitem.children('ul.submenu').attr('aria-hidden', 'true').hide();
       thisTopMenuitem.children().first().find('[aria-expanded]').attr('aria-expanded', 'false');
     }
     e.stopPropagation();
@@ -778,7 +787,7 @@ $(function() {
     //console.log('doing hideAllTopMenuitems');
     var topTierUl = $(document).find('nav[aria-label=Toolbar] ul[id=topTierUl]');
     topTierUl.find('[aria-expanded]').attr('aria-expanded', 'false');
-    topTierUl.find('ul[role=menu]').attr('aria-hidden', 'true').hide();
+    topTierUl.find('ul.submenu').attr('aria-hidden', 'true').hide();
   }
 
   function switchTopMenuitem(topTierUl, destTopMenuitem, destElt) {
@@ -789,7 +798,7 @@ $(function() {
       var elt = destTopMenuitem[0];
       var eltId = elt.getAttribute('id');
       if (eltId !== 'rundropdownli') {
-        destTopMenuitem.children('ul[role=menu]').attr('aria-hidden', 'false').show();
+        destTopMenuitem.children('ul.submenu').attr('aria-hidden', 'false').show();
         destTopMenuitem.children().first().find('[aria-expanded]').attr('aria-expanded', 'true');
       }
     }
@@ -804,7 +813,7 @@ $(function() {
     //$(this).blur(); // Delete?
     var withinSecondTierUl = true;
     var topTierUl = $(this).closest('ul[id=topTierUl]');
-    var secondTierUl = $(this).closest('ul[role=menu]');
+    var secondTierUl = $(this).closest('ul.submenu');
     if (secondTierUl.length === 0) {
       withinSecondTierUl = false;
     }
@@ -900,7 +909,7 @@ $(function() {
         } else {
           /*
           //console.log('no actionable submenu found')
-          var topmenuItem = $(this).closest('ul[role=menu]').closest('li')
+          var topmenuItem = $(this).closest('ul.submenu').closest('li')
           .children().first().find('.focusable:not([disabled])').filter(':visible');
           if (topmenuItem.length > 0) {
             topmenuItem.first().focus();

--- a/src/web/js/share.js
+++ b/src/web/js/share.js
@@ -62,7 +62,7 @@ window.makeShareAPI = function makeShareAPI(pyretVersion) {
   $(".menuButton a").click(hideAllHovers);
 
   function makeShareLink(originalFile) {
-    var link = $('<button aria-label="Publish, F9" aria-describedby="publishInfo" class="focusable blueButton" role="treeitem" tabindex="-1">').text("Publish");
+    var link = $('<button aria-label="Publish, F9" aria-describedby="publishInfo" class="focusable blueButton" role="menuitem" tabindex="-1">').text("Publish");
     var shareDiv = $("<div>").addClass("share");
     link.click(function() { showShares(shareDiv, originalFile); });
     return link;


### PR DESCRIPTION
Make sure cycleFocus to Toolbar always lands on Bonnie (no statefulness).
Clean up HTML to satisfy validation.
Avoid tree itemization. Set <nav> to role=menubar and both <ul>s
of menu system to role=menu; menu items have role=menuitem; for
canonical posinset reading.
Standardize aria-describedby for menu and submenu.