### PR TITLE
Further a11y enhancements

### DIFF
--- a/cpo-standalone.js
+++ b/cpo-standalone.js
@@ -157,6 +157,7 @@ requirejs(["pyret-base/js/runtime", "pyret-base/js/post-load-hooks", "pyret-base
         $("#runDropdown").attr("disabled", false);
         clearInterval($("#loader").data("intervalID"));
         $("#loader").hide();
+        CPO.say('Pyret loaded and ready.');
         console.log("REPL ready.");
       });
     }

--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -462,8 +462,7 @@ div.spy-block > table > th { display: none; }
   display: inline-block;
 }
 
-.repl-echo::before,
-.repl-prompt::before {
+.repl-prompt-sign::before {
   content: '\203a\203a\203a';
   display: inline;
   line-height: calc(1em + 10px);

--- a/src/web/css/shared.css
+++ b/src/web/css/shared.css
@@ -481,3 +481,28 @@ code {
 .focusable:focus {
   background: rgba(0,0,0,0.3);
 }
+
+.tooltip {
+  position: relative;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  top: 5ex;
+  left: 5ex;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}

--- a/src/web/css/shared.css
+++ b/src/web/css/shared.css
@@ -170,6 +170,11 @@ em {
   box-shadow: 0px 1px 2px rgba(0,0,0,0.6);
 }
 
+nav > div {
+  width: 100%;
+  height: 100%;
+}
+
 /*
 #header div a {
   width: 100px;
@@ -208,7 +213,7 @@ nav a, nav button {
   font-family: sans-serif;
 }
 
-nav > ul {
+nav > div > ul {
   display: flex;
   flex-flow: row wrap;
   height: 100%;
@@ -218,7 +223,7 @@ nav > ul {
   list-style-type: none;
 }
 
-nav > ul > li {
+nav > div > ul > li {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -227,30 +232,30 @@ nav > ul > li {
   list-style-type: none;
 }
 
-nav > ul > li  ul {
+nav > div > ul > li  ul {
   position: absolute;
   top: 2.5em;
   margin: 0;
   padding: 0;
-  aria-hidden: true;
+  /* aria-hidden: true; */
   display: none;
   list-style-type: none;
 }
 
-nav > ul > li > ul:not([id="run-dropdown-content"]) {
+nav > div > ul > li > ul:not([id="run-dropdown-content"]) {
   left: 0;
 }
 
-nav > ul > li > ul[id="run-dropdown-content"] {
+nav > div > ul > li > ul[id="run-dropdown-content"] {
   left: -150px;
 }
 
-nav > ul > li:focus ul {
-  aria-hidden: false;
+nav > div > ul > li:focus ul {
+  /* aria-hidden: false; */
   display: block;
 }
 
-nav > ul ul > li {
+nav > div > ul ul > li {
   /* height: 20px; */
   float: none;
   position: static;
@@ -265,7 +270,7 @@ ul[role="menu"] > li {
   padding: 0;
 }
 
-nav > ul ul > li > div {
+nav > div > ul ul > li > div {
   margin: 0;
   padding: 0;
   /* border: thin solid cyan; */
@@ -283,7 +288,7 @@ nav > ul ul > li > div {
   padding: 0;
 }
 
-nav > ul ul a, nav > ul ul button {
+nav > div > ul ul a, nav > div > ul ul button {
   float: none;
   display: block;
   overflow: hidden;
@@ -311,7 +316,8 @@ li.topTier > div {
 }
 
 .menu {
-  display: inline-block;
+  display: block;
+  /* display: inline-block; */
   height: 100%;
   vertical-align: top;
   float:left;  /*latest*/
@@ -365,7 +371,7 @@ li.topTier > div {
 }
 
 .blueButton:disabled {
-    background-color: none;
+    background-color: #C8C8C8;
     border: none;
     color: rgba(0, 0, 0, 0.26);
     cursor: default;

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -34,26 +34,36 @@
         aria-label="Toolbar" tabindex="-1">
         <li role="presentation"
           class="topTier" id="bonniemenuli">
-          <div id="bonniemenu" class="menu menuitemtitle" style="float:none" >
+          <div id="bonniemenu" class="tooltip menu menuitemtitle" style="float:none" >
             <button role="menuitem"
                     id="bonniemenubutton"
-                    aria-label="Main Menu, Press Ctrl-Question for list of keyboard shortcuts"
+                    aria-label="Pyret Menu"
                     aria-haspopup="true"
                     aria-expanded="false"
-                    aria-controls="bonniemenuContents"
                     aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
                     tabindex="-1"
                     class="blueButton focusable">
               <span>▾</span>
               <img class="logo" src="/img/pyret-logo.png">
             </button>
+            <span class="tooltiptext">
+              Pyret menu!
+            </span>
           </div>
           <ul id="bonniemenuContents" class="menuContents submenu" role="menu" aria-hidden="true"
-            aria-label="Main Submenu">
+            aria-label="Pyret Menu">
             <li role="presentation">
               <div id="welcome" class="menuButton inert" style="text-align: center;">
                 <span>Welcome, <span id="username" style="display: inline; padding: 0px;">guest</span>!</span>
-                <span>Press Ctrl-? for list of keyboard shortcuts.</span>
+              </div>
+            </li>
+            <li role="presentation">
+              <div id="ctrl-question" class="menuButton">
+                <a class="focusable" role="menuitem"
+                  aria-label="keyboard shortcuts"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
+                  tabindex="-1" href="javascript:void(0)"
+                  >Keyboard shortcuts, Ctrl-?</a>
               </div>
             </li>
             <li role="presentation">
@@ -133,7 +143,6 @@
               aria-label="File"
               aria-haspopup="true"
               aria-expanded="false"
-              aria-controls="filemenuContents"
               aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
               id="filemenuItem"
               tabindex="-1"
@@ -219,7 +228,6 @@
                     aria-label="Run Options"
                     aria-haspopup="true"
                     aria-expanded="false"
-                    aria-controls="run-dropdown-content"
                     aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
                     disabled
                     tabindex="-1">↴

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -17,20 +17,18 @@
 <body>
   <main>
   <div id="Toolbar" class="toolbarregion" role="region" aria-label="Tool Controls" tabindex="-1">
-    <nav aria-label="Toolbar" role="menubar" id="header">
+    <nav id="header">
       <h2 id="menutitle" class="screenreader-only">Navigation Controls</h2>
       <p class="screenreader-only" id="mhelp">
-      <span id="mhelp-intro">The toolbar menu has at most two levels, with some top-level
-        menu items having a submenu.</span>
-      <span id="mhelp-menus">Use left and right arrows to navigate across the top-level menu items.
+      <span id="mhelp-menus">Use left and right arrows to move across menus.
       </span>
-      <span id="mhelp-submenu">Use up and down arrows to explore within a submenu.
+      <span id="mhelp-submenu">Use up and down arrows to move within submenus.
       </span>
-      <span id="mhelp-activate">Use Enter, Space, or Click to activate.</span>
-      <span id="mhelp-escape-submenu">Use left and right arrows to exit submenu and go to an
-        adjacent top-level menu item.</span>
-      <span id="mhelp-escape">Use Escape, Tab, F6 or Shift-F6 to exit these menus altogether.</span>
+      <span id="mhelp-activate">Use Enter to activate.</span>
+      <span id="mhelp-escape-submenu">Use Escape to move to parent menu.</span>
+      <span id="mhelp-escape">Use Escape to exit menus.</span>
       </p>
+      <div role="menubar">
       <ul id="topTierUl" role="menu" aria-labelledby="menutitle"
         aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
         aria-label="Toolbar" tabindex="-1">
@@ -40,7 +38,6 @@
             <button role="menuitem"
                     id="bonniemenubutton"
                     aria-label="Main Menu, Press Ctrl-Question for list of keyboard shortcuts"
-                    aria-describedby="mhelp-menus mhelp-activate mhelp-escape"
                     aria-haspopup="true"
                     aria-expanded="false"
                     aria-controls="bonniemenuContents"
@@ -48,7 +45,7 @@
                     tabindex="-1"
                     class="blueButton focusable">
               <span>▾</span>
-              <img class="logo" src="/img/pyret-logo.png"></img>
+              <img class="logo" src="/img/pyret-logo.png">
             </button>
           </div>
           <ul id="bonniemenuContents" class="menuContents submenu" role="menu" aria-hidden="true"
@@ -62,7 +59,7 @@
             <li role="presentation">
               <div id="drive-view" class="loginOnly menuButton">
                 <a class="focusable" role="menuitem"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" target="_blank" href="/">
                   My Programs</a>
               </div>
@@ -70,7 +67,7 @@
             <li role="presentation">
               <div id="docs" class="menuButton">
                 <a class="focusable" role="menuitem"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" target="_blank" href="http://pyret.org/docs/{{{ CURRENT_PYRET_DOCS }}}">Documentation</a>
               </div>
             </li>
@@ -81,14 +78,14 @@
             <li role="presentation">
               <div id="issues" class="menuButton">
                 <a class="focusable" role="menuitem"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" target="_blank" href="https://github.com/brownplt/pyret-lang/issues/new">Report an Issue</a>
               </div>
             </li>
             <li role="presentation">
               <div id="discuss" class="menuButton">
                 <a class="focusable" role="menuitem"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" target="_blank" href="https://groups.google.com/forum/#!forum/pyret-discuss">Discuss Pyret</a>
               </div>
             </li>
@@ -97,7 +94,7 @@
                 <span>
                   <input class="focusable" role="menuitem" tabindex="-1" id="detailed-logging"
                   aria-labelledby="detailed-logging-label"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   type="checkbox" aria-pressed="false"
                   aria-label="Contribute detailed usage information"/>
                   <label for="detailed-logging" id="detailed-logging-label">
@@ -110,7 +107,7 @@
             </li>
             <li role="presentation">
               <div id="logout" class="menuButton">
-                <a class="focusable" aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                <a class="focusable" aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   role="menuitem" tabindex="-1" href="/logout">Log out</a>
               </div>
             </li>
@@ -150,43 +147,43 @@
             <li role="presentation">
               <div id="new" class="menuButton">
                 <a class="focusable" role="menuitem" aria-label="New file"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)" >New</a></div>
             </li>
             <li role="presentation">
               <div id="open" class="menuButton">
                 <a  class="focusable" role="menuitem" aria-label="Open file"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Open</a></div>
             </li>
             <li role="presentation">
               <div id="open-original" class="menuButton disabled hidden">
                 <a class="focusable" role="menuitem" aria-label="Open original file"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Open Original</a></div>
             </li>
             <li role="presentation">
               <div id="save" class="menuButton disabled">
                 <a class="focusable disabled" role="menuitem" aria-label="Save file"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Save</a></div>
             </li>
             <li role="presentation">
               <div id="saveas" class="menuButton">
                 <a class="focusable" role="menuitem" aria-label="Save a copy"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Save a copy</a></div>
             </li>
             <li role="presentation">
               <div id="download" class="menuButton">
                 <a class="focusable" role="menuitem" aria-label="Download"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Download</a></div>
             </li>
             <li role="presentation">
               <div id="rename" class="menuButton disabled">
                 <a class="focusable disabled" role="menuitem" aria-label="Rename file"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Rename</a></div>
             </li>
           </ul>
@@ -235,7 +232,7 @@
                 <a class="focusable"
                   role="menuitem"
                   aria-label="Run" aria-setsize="2" aria-posinset="1"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Run</a>
               </div>
             </li>
@@ -244,7 +241,7 @@
                 <a class="focusable"
                   role="menuitem"
                   aria-label="Type-check and run" aria-setsize="2" aria-posinset="2"
-                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu mhelp-escape"
+                  aria-describedby="mhelp-submenu mhelp-activate mhelp-escape-submenu"
                   tabindex="-1" href="javascript:void(0)">Type-check and run<sup>(beta)</sup></a>
               </div>
             </li>
@@ -258,8 +255,8 @@
               class="focusable blueButton"  tabindex="-1">Stop</button>
           </div>
         </li>
-
       </ul>
+      </div>
     </nav>
   </div>
 
@@ -322,7 +319,7 @@
 </div>
 </div>
 <div id="footer">
-  <div id="announcements" class="screenreader-only" role="region" aria-label="Announcements" tabIndex="-1">
+  <div id="announcements" class="screenreader-only" role="region" aria-label="Announcements" tabindex="-1">
     <h2>Announcements</h2>
     <ul id="announcementlist" aria-live="assertive"
                               aria-relevant="additions" style="list-style: none;">

--- a/src/web/faq.html
+++ b/src/web/faq.html
@@ -3,10 +3,10 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>code.pyret.org</title>
-  <link rel="stylesheet" href="/css/reset.css"></link>
+  <link rel="stylesheet" href="/css/reset.css" />
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
-  <link rel="stylesheet" href="/css/shared.css"></link>
-  <link rel="stylesheet" href="/css/my-programs.css"></link>
+  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/my-programs.css" />
   <style>
 #header {
  display:flex;
@@ -35,7 +35,7 @@ h4 {
 
 <h3>What permissions does code.pyret.org ask for and why?</h3>
 
-<p>code.pyret.org asks for several permissions when you log in:
+<p>code.pyret.org asks for several permissions when you log in:</p>
 
 <ul>
 
@@ -125,4 +125,4 @@ programs and the edits you make.</p>
 
 </div>
 </body>
-
+</html>

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -444,7 +444,7 @@ $(function() {
   }
 
   function cycleFocus(reverseP) {
-    console.log('doing cycleFocus', reverseP);
+    //console.log('doing cycleFocus', reverseP);
     var editor = this.editor;
     populateFocusCarousel(editor);
     var fCarousel = editor.focusCarousel;
@@ -742,19 +742,6 @@ $(function() {
       // an arrow
       var target = $(this).find('[tabIndex=-1]');
       getTopTierMenuitems();
-      /*
-      //console.log('target=', target);
-      //console.log('target.len=', target.length);
-      var topTierLi = target.closest('li.topTier');
-      //console.log('topTierLi=', topTierLi.length);
-      if (topTierLi.length === 0) {
-        topTierLi = $('#bonniemenuli')
-        // go straight here?
-        target = topTierLi.find('.focusable').first();
-      }
-      switchTopMenuitem(topTierLi.closest('ul[id=topTierUl]'), topTierLi, target);
-      //console.log('docactelt=', document.activeElement);
-      */
       document.activeElement.blur(); //needed?
       target.first().focus(); //needed?
       //console.log('docactelt=', document.activeElement);
@@ -798,8 +785,8 @@ $(function() {
     topTierUl.find('ul.submenu').attr('aria-hidden', 'true').hide();
   }
 
-  function switchTopMenuitem(topTierUl, destTopMenuitem, destElt) {
-    //console.log('doing switchTopMenuitem', topTierUl, destTopMenuitem, destElt);
+  function switchTopMenuitem(destTopMenuitem, destElt) {
+    //console.log('doing switchTopMenuitem', destTopMenuitem, destElt);
     //console.log('dtmil=', destTopMenuitem.length);
     hideAllTopMenuitems();
     if (destTopMenuitem && destTopMenuitem.length !== 0) {
@@ -826,7 +813,7 @@ $(function() {
     if (e.keyCode === 27 && withinSecondTierUl) { // escape
       var destTopMenuitem = $(this).closest('li.topTier');
       var possElts = destTopMenuitem.find('.focusable:not([disabled])').filter(':visible');
-      switchTopMenuitem(topTierUl, destTopMenuitem, possElts.first());
+      switchTopMenuitem(destTopMenuitem, possElts.first());
       e.stopPropagation();
     } else if (e.keyCode === 39) { // rightarrow
       //console.log('rightarrow pressed');
@@ -846,7 +833,7 @@ $(function() {
         if (possElts.length > 0) {
           //console.log('final i=', i);
           //console.log('landing on', possElts.first());
-          switchTopMenuitem(topTierUl, destTopMenuitem, possElts.first());
+          switchTopMenuitem(destTopMenuitem, possElts.first());
           e.stopPropagation();
           break;
         }
@@ -870,7 +857,7 @@ $(function() {
         if (possElts.length > 0) {
           //console.log('final i=', i);
           //console.log('landing on', possElts.first());
-          switchTopMenuitem(topTierUl, destTopMenuitem, possElts.first());
+          switchTopMenuitem(destTopMenuitem, possElts.first());
           e.stopPropagation();
           break;
         }
@@ -960,14 +947,17 @@ $(function() {
       e.stopPropagation();
     } else if (e.keyCode === 27) {
       //console.log('esc pressed');
-      switchTopMenuitem(topTierUl, undefined);
+      hideAllTopMenuitems();
       //console.log('calling cycleFocus ii')
       CPO.cycleFocus();
       e.stopPropagation();
       e.preventDefault();
       //$(this).closest('nav').closest('main').focus();
-    } else if (e.keyCode === 9) {
-      console.log('tab pressed\n')
+    } else if (e.keyCode === 9 ) {
+      if (e.shiftKey) {
+        hideAllTopMenuitems();
+        CPO.cycleFocus(true);
+      }
       e.stopPropagation();
       e.preventDefault();
     } else if (e.keyCode === 32) {

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -444,9 +444,8 @@ $(function() {
   }
 
   function cycleFocus(reverseP) {
-    //console.log('doing cycleFocus', reverseP);
+    console.log('doing cycleFocus', reverseP);
     var editor = this.editor;
-    var fCarousel = editor.focusCarousel;
     populateFocusCarousel(editor);
     var fCarousel = editor.focusCarousel;
     var maxIndex = fCarousel.length;
@@ -545,17 +544,18 @@ $(function() {
 
   */
   function save(newFilename) {
+    var useName, create;
     if(newFilename !== undefined) {
-      var useName = newFilename;
-      var create = true;
+      useName = newFilename;
+      create = true;
     }
     else if(filename === false) {
       filename = "Untitled";
-      var create = true;
+      create = true;
     }
     else {
-      var useName = filename; // A closed-over variable
-      var create = false;
+      useName = filename; // A closed-over variable
+      create = false;
     }
     window.stickMessage("Saving...");
     var savedProgram = programToSave.then(function(p) {
@@ -672,13 +672,13 @@ $(function() {
   $("#rename").click(rename);
   $("#saveas").click(saveAs);
 
-  var focusableElts = $(document).find('nav[aria-label=Toolbar] .focusable');
+  var focusableElts = $(document).find('#header .focusable');
   //console.log('focusableElts=', focusableElts)
   var theToolbar = $(document).find('#Toolbar');
 
   function getTopTierMenuitems() {
     //console.log('doing getTopTierMenuitems')
-    var topTierMenuitems = $(document).find('nav[aria-label=Toolbar] ul li.topTier').toArray();
+    var topTierMenuitems = $(document).find('#header ul li.topTier').toArray();
     topTierMenuitems = topTierMenuitems.
                         filter(elt => !(elt.style.display === 'none' ||
                                         elt.getAttribute('disabled') === 'disabled'));
@@ -732,13 +732,13 @@ $(function() {
     //most any key at all
     var kc = e.keyCode;
     //console.log('toolbar keydown', e.keyCode);
-    if (kc === 9 || kc === 27) {
+    if (kc === 27) {
       // escape
       hideAllTopMenuitems();
       //console.log('calling cycleFocus')
       CPO.cycleFocus();
       e.stopPropagation();
-    } else if (kc === 37 || kc === 38 || kc === 39 || kc === 40) {
+    } else if (kc === 9 || kc === 37 || kc === 38 || kc === 39 || kc === 40) {
       // an arrow
       var target = $(this).find('[tabIndex=-1]');
       getTopTierMenuitems();
@@ -788,12 +788,12 @@ $(function() {
     e.stopPropagation();
   }
 
-  var expandableElts = $(document).find('nav[aria-label=Toolbar] [aria-expanded]');
+  var expandableElts = $(document).find('#header [aria-expanded]');
   expandableElts.click(clickTopMenuitem);
 
   function hideAllTopMenuitems() {
     //console.log('doing hideAllTopMenuitems');
-    var topTierUl = $(document).find('nav[aria-label=Toolbar] ul[id=topTierUl]');
+    var topTierUl = $(document).find('#header ul[id=topTierUl]');
     topTierUl.find('[aria-expanded]').attr('aria-expanded', 'false');
     topTierUl.find('ul.submenu').attr('aria-hidden', 'true').hide();
   }
@@ -805,10 +805,8 @@ $(function() {
     if (destTopMenuitem && destTopMenuitem.length !== 0) {
       var elt = destTopMenuitem[0];
       var eltId = elt.getAttribute('id');
-      if (eltId !== 'rundropdownli') {
-        destTopMenuitem.children('ul.submenu').attr('aria-hidden', 'false').show();
-        destTopMenuitem.children().first().find('[aria-expanded]').attr('aria-expanded', 'true');
-      }
+      destTopMenuitem.children('ul.submenu').attr('aria-hidden', 'false').show();
+      destTopMenuitem.children().first().find('[aria-expanded]').attr('aria-expanded', 'true');
     }
     if (destElt) {
       //destElt.attr('tabIndex', '0').focus();
@@ -825,16 +823,14 @@ $(function() {
     if (secondTierUl.length === 0) {
       withinSecondTierUl = false;
     }
-    if (e.keyCode === 39) { // rightarrow
+    if (e.keyCode === 27 && withinSecondTierUl) { // escape
+      var destTopMenuitem = $(this).closest('li.topTier');
+      var possElts = destTopMenuitem.find('.focusable:not([disabled])').filter(':visible');
+      switchTopMenuitem(topTierUl, destTopMenuitem, possElts.first());
+      e.stopPropagation();
+    } else if (e.keyCode === 39) { // rightarrow
       //console.log('rightarrow pressed');
-      var bubbleUp;
-      if (withinSecondTierUl) {
-        bubbleUp = secondTierUl;
-      } else {
-        bubbleUp = $(this);
-      }
-      //console.log('bubbleUp=', bubbleUp)
-      var srcTopMenuitem = bubbleUp.closest('li.topTier');
+      var srcTopMenuitem = $(this).closest('li.topTier');
       //console.log('srcTopMenuitem=', srcTopMenuitem);
       srcTopMenuitem.children().first().find('.focusable').attr('tabIndex', '-1');
       var topTierMenuitems = getTopTierMenuitems();
@@ -842,7 +838,7 @@ $(function() {
       var ttmiN = topTierMenuitems.length;
       var j = topTierMenuitems.indexOf(srcTopMenuitem[0]);
       //console.log('j initial=', j);
-      for (var i = (j + 1) % ttmiN; i != j; i = (i + 1) % ttmiN) {
+      for (var i = (j + 1) % ttmiN; i !== j; i = (i + 1) % ttmiN) {
         var destTopMenuitem = $(topTierMenuitems[i]);
         //console.log('destTopMenuitem(a)=', destTopMenuitem);
         var possElts = destTopMenuitem.find('.focusable:not([disabled])').filter(':visible');
@@ -857,14 +853,7 @@ $(function() {
       }
     } else if (e.keyCode === 37) { // leftarrow
       //console.log('leftarrow pressed');
-      var bubbleUp;
-      if (withinSecondTierUl) {
-        bubbleUp = secondTierUl;
-      } else {
-        bubbleUp = $(this);
-      }
-      //console.log('bubbleUp=', bubbleUp)
-      var srcTopMenuitem = bubbleUp.closest('li');
+      var srcTopMenuitem = $(this).closest('li.topTier');
       //console.log('srcTopMenuitem=', srcTopMenuitem);
       srcTopMenuitem.children().first().find('.focusable').attr('tabIndex', '-1');
       var topTierMenuitems = getTopTierMenuitems();
@@ -872,7 +861,7 @@ $(function() {
       var ttmiN = topTierMenuitems.length;
       var j = topTierMenuitems.indexOf(srcTopMenuitem[0]);
       //console.log('j initial=', j);
-      for (var i = (j + ttmiN - 1) % ttmiN; i != j; i = (i + ttmiN - 1) % ttmiN) {
+      for (var i = (j + ttmiN - 1) % ttmiN; i !== j; i = (i + ttmiN - 1) % ttmiN) {
         var destTopMenuitem = $(topTierMenuitems[i]);
         //console.log('destTopMenuitem(b)=', destTopMenuitem);
         //console.log('i=', i)
@@ -969,14 +958,18 @@ $(function() {
         //console.log('no actionable submenu found')
       }
       e.stopPropagation();
-    } else if (e.keyCode === 9 || e.keyCode === 27) {
-      //console.log('tab/esc pressed');
+    } else if (e.keyCode === 27) {
+      //console.log('esc pressed');
       switchTopMenuitem(topTierUl, undefined);
       //console.log('calling cycleFocus ii')
       CPO.cycleFocus();
       e.stopPropagation();
       e.preventDefault();
       //$(this).closest('nav').closest('main').focus();
+    } else if (e.keyCode === 9) {
+      console.log('tab pressed\n')
+      e.stopPropagation();
+      e.preventDefault();
     } else if (e.keyCode === 32) {
       //console.log('clicked space on', $(this));
       //$(this)[0].click();
@@ -1029,7 +1022,7 @@ $(function() {
     var rulers = CPO.editor.cm.getOption("rulers");
     var longLines = CPO.editor.cm.getOption("longLines");
     var minLength;
-    if (longLines.size == 0) {
+    if (longLines.size === 0) {
       minLength = 0; // if there are no long lines, then we don't care about showing any rulers
     } else {
       minLength = Number.MAX_VALUE;

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -729,9 +729,9 @@ $(function() {
   });
 
   theToolbar.keydown(function (e) {
+    //console.log('toolbar keydown', e);
     //most any key at all
     var kc = e.keyCode;
-    //console.log('toolbar keydown', e.keyCode);
     if (kc === 27) {
       // escape
       hideAllTopMenuitems();
@@ -802,7 +802,8 @@ $(function() {
   }
 
   focusableElts.keydown(function (e) {
-    //console.log('focusable elt keydown', e.keyCode);
+    //console.log('focusable elt keydown', e);
+    var kc = e.keyCode;
     //$(this).blur(); // Delete?
     var withinSecondTierUl = true;
     var topTierUl = $(this).closest('ul[id=topTierUl]');
@@ -810,12 +811,12 @@ $(function() {
     if (secondTierUl.length === 0) {
       withinSecondTierUl = false;
     }
-    if (e.keyCode === 27 && withinSecondTierUl) { // escape
+    if (kc === 27 && withinSecondTierUl) { // escape
       var destTopMenuitem = $(this).closest('li.topTier');
       var possElts = destTopMenuitem.find('.focusable:not([disabled])').filter(':visible');
       switchTopMenuitem(destTopMenuitem, possElts.first());
       e.stopPropagation();
-    } else if (e.keyCode === 39) { // rightarrow
+    } else if (kc === 39) { // rightarrow
       //console.log('rightarrow pressed');
       var srcTopMenuitem = $(this).closest('li.topTier');
       //console.log('srcTopMenuitem=', srcTopMenuitem);
@@ -838,7 +839,7 @@ $(function() {
           break;
         }
       }
-    } else if (e.keyCode === 37) { // leftarrow
+    } else if (kc === 37) { // leftarrow
       //console.log('leftarrow pressed');
       var srcTopMenuitem = $(this).closest('li.topTier');
       //console.log('srcTopMenuitem=', srcTopMenuitem);
@@ -862,7 +863,7 @@ $(function() {
           break;
         }
       }
-    } else if (e.keyCode === 38) { // uparrow
+    } else if (kc === 38) { // uparrow
       //console.log('uparrow pressed');
       var submenu;
       if (withinSecondTierUl) {
@@ -904,7 +905,7 @@ $(function() {
         }
       }
       e.stopPropagation();
-    } else if (e.keyCode === 40) { // downarrow
+    } else if (kc === 40) { // downarrow
       //console.log('downarrow pressed');
       var submenuDivs;
       var submenu;
@@ -945,7 +946,7 @@ $(function() {
         //console.log('no actionable submenu found')
       }
       e.stopPropagation();
-    } else if (e.keyCode === 27) {
+    } else if (kc === 27) {
       //console.log('esc pressed');
       hideAllTopMenuitems();
       //console.log('calling cycleFocus ii')
@@ -953,20 +954,17 @@ $(function() {
       e.stopPropagation();
       e.preventDefault();
       //$(this).closest('nav').closest('main').focus();
-    } else if (e.keyCode === 9 ) {
+    } else if (kc === 9 ) {
       if (e.shiftKey) {
         hideAllTopMenuitems();
         CPO.cycleFocus(true);
       }
       e.stopPropagation();
       e.preventDefault();
-    } else if (e.keyCode === 32) {
-      //console.log('clicked space on', $(this));
-      //$(this)[0].click();
+    } else if (kc === 13 || kc === 17 || kc === 20 || kc === 32) {
+      // 13=enter 17=ctrl 20=capslock 32=space
       e.stopPropagation();
-    } else if (e.keyCode === 13) {
-      //console.log('enter pressed');
-      //$(this).click();
+    } else {
       e.stopPropagation();
     }
     //e.stopPropagation();

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -561,6 +561,10 @@
         e.preventDefault();
       });
 
+      $('#ctrl-question').click(function() {
+        $('#help-keys').fadeIn(100);
+        reciteHelp();
+      });
 
       Mousetrap.bindGlobal('f6', function(e) {
         // cycle focus (forward)

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -576,6 +576,14 @@
         e.preventDefault();
       });
 
+      Mousetrap.bindGlobal('shift+tab', function(e) {
+        // cycle focus backward
+        //console.log('mouse shift+tab')
+        CPO.cycleFocus(true);
+        e.stopImmediatePropagation();
+        e.preventDefault();
+      });
+
       Mousetrap.bindGlobal('f7', function(e) {
         doRunAction(editor.cm.getValue());
         CPO.autoSave();

--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -381,6 +381,9 @@
 
       var promptContainer = jQuery("<div class='prompt-container'>");
       var prompt = jQuery("<span>").addClass("repl-prompt").attr("title", "Enter Pyret code here");
+      var promptSign = $('<span aria-hidden="true" aria-label="REPL prompt">').
+        addClass('repl-prompt-sign');
+      prompt.append(promptSign);
       function showPrompt() {
         promptContainer.hide();
         promptContainer.fadeIn(100);
@@ -857,6 +860,9 @@
         pointer = -1;
         var echoContainer = $("<div class='echo-container'>");
         var echoSpan = $("<span>").addClass("repl-echo");
+        var echoPromptSign = $('<span aria-hidden="true" aria-label="REPL prompt">').
+          addClass('repl-prompt-sign');
+        echoSpan.append(echoPromptSign);
         var echo = $("<textarea>");
         echoSpan.append(echo);
         echoContainer.append(echoSpan);

--- a/src/web/share.template.html
+++ b/src/web/share.template.html
@@ -3,10 +3,10 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>code.pyret.org</title>
-  <link rel="stylesheet" href="/css/reset.css"></link>
+  <link rel="stylesheet" href="/css/reset.css" />
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
-  <link rel="stylesheet" href="/css/shared.css"></link>
-  <link rel="stylesheet" href="/css/share.css"></link>
+  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/share.css" />
 </head>
 <body>
 <div id="loader" style="top: 80px;"><p></p></div>


### PR DESCRIPTION
- `<nav>` should enclose, not be, the menubar
- Run dropdown submenu is like every other submenu
- Top menu's and submenus' ARIA help should be appropriately different: `Escape` in submenu only exits submenu, whereas `Escape` in top menu exits nav region altogether
- Keep REPL prompt in own container, so it can have its own ARIA recitation
- `Shift-Tab` cycles focus backward as this is traditional behavior (even if we can't have `Tab` do cycle focus forward)
- Audio-announce when Pyret is loaded and ready (i.e., when the "debarnacling" messages have died down)
- Ensure tool bar submenus don't react to extraneous keys, in particular `Ctrl` shouldn't exit tool bar
- Add "Keyboard shortcuts" (with its own shortcut `C-?`) as an actionable rather than informational item in the Bonnie submenu
- The Bonnie menu is formally called the Pyret menu. Add a hover tooltip to remind user/teacher of this