### PR TITLE
More a11y fixes, ii

### DIFF
--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -1256,6 +1256,10 @@ code div {
   box-shadow: none;
 }
 
+#runButton:disabled, #runDropdown:disabled {
+  color: #111;
+}
+
 #runButton:hover[disabled],
 #breakButton:hover[disabled]{
   background: none;
@@ -1324,7 +1328,6 @@ code div {
 }
 
 #run-dropdown-content > li {
-  background: #317BCF;
   color: #eeeeee;
   font-family: sans-serif;
   font-size: 15px;

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -47,7 +47,7 @@
               <img class="logo" src="/img/pyret-logo.png">
             </button>
             <span class="tooltiptext">
-              Pyret menu!
+              Pyret menu
             </span>
           </div>
           <ul id="bonniemenuContents" class="menuContents submenu" role="menu" aria-hidden="true"

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -695,7 +695,10 @@ $(function() {
   }
 
   function updateEditorHeight() {
-    var toolbarHeight = document.getElementById('topTierUl').scrollHeight + 'px';
+    var toolbarHeight = document.getElementById('topTierUl').scrollHeight;
+    // gets bumped to 67 on initial resize perturbation, but actual value is indeed 40
+    if (toolbarHeight < 80) toolbarHeight = 40;
+    toolbarHeight += 'px';
     document.getElementById('REPL').style.paddingTop = toolbarHeight;
     var docMain = document.getElementById('main');
     var docReplMain = docMain.getElementsByClassName('replMain');
@@ -752,10 +755,16 @@ $(function() {
   });
 
   function clickTopMenuitem(e) {
+    hideAllTopMenuitems();
     var thisElt = $(this);
     //console.log('doing clickTopMenuitem on', thisElt);
     var topTierUl = thisElt.closest('ul[id=topTierUl]');
-    if (thisElt[0].hasAttribute('aria-hidden')) return;
+    if (thisElt[0].hasAttribute('aria-hidden')) {
+      return;
+    }
+    if (thisElt[0].getAttribute('disabled') === 'disabled') {
+      return;
+    }
     //var hiddenP = (thisElt[0].getAttribute('aria-expanded') === 'false');
     //hiddenP always false?
     var thisTopMenuitem = thisElt.closest('li.topTier');
@@ -784,6 +793,9 @@ $(function() {
     topTierUl.find('[aria-expanded]').attr('aria-expanded', 'false');
     topTierUl.find('ul.submenu').attr('aria-hidden', 'true').hide();
   }
+
+  var nonexpandableElts = $(document).find('#header .topTier > div > button:not([aria-expanded])');
+  nonexpandableElts.click(hideAllTopMenuitems);
 
   function switchTopMenuitem(destTopMenuitem, destElt) {
     //console.log('doing switchTopMenuitem', destTopMenuitem, destElt);

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -58,7 +58,7 @@
 
 
     var replContainer = $("<div>").addClass("repl");
-    replContainer.attr("tabindex", "-1");
+    replContainer.attr("tabindex", "-1").attr('role', 'application');
     //replContainer.attr("aria-hidden", "true");
     $("#REPL").append(replContainer);
 
@@ -324,7 +324,8 @@
       var replWidget =
           replUI.makeRepl(replContainer, repl, runtime, {
             breakButton: $("#breakButton"),
-            runButton: runButton
+            runButton: runButton,
+            runDropdown: $('#runDropdown')
           });
 
       // NOTE(joe): assigned on window for debuggability

--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -349,11 +349,17 @@
               recital += ' produced output: ';
             }
           } else {
-            recital += ' evaluates to ';
+            if (!history.start) {
+              recital += ' produced no output.';
+            } else {
+              recital += ' evaluates to ';
+            }
           }
           var docOutput = document.getElementById('output').childNodes;
-          if (!history.end && history.start) {
-            recital += outputText(docOutput[history.start]);
+          if (!history.end) {
+            if (history.start) {
+              recital += outputText(docOutput[history.start]);
+            }
           } else {
             //console.log('speakhistory from', history.start, 'to', history.end);
             for (var i = history.start; i < history.end; i++) {
@@ -646,6 +652,8 @@
           //console.log('result is a successful load, 0 to', docOutputLen);
           thiscode.start = 0;
           thiscode.end = docOutputLen;
+        } else if (lastOutput && lastOutput.classList.contains('echo-container')) {
+          thiscode.start = false;
         } else {
           //console.log('result is a successful single interaction');
           thiscode.start = docOutputLen - 1;
@@ -663,6 +671,7 @@
           options.runButton.empty();
           options.runButton.append(runContents);
           options.runButton.attr("disabled", false);
+          options.runDropdown.attr('disabled', false);
           breakButton.attr("disabled", true);
           stopLi.attr('disabled', true);
           canShowRunningIndicator = false;
@@ -684,6 +693,7 @@
         setTimeout(function() {
          if(canShowRunningIndicator) {
             options.runButton.attr("disabled", true);
+            options.runDropdown.attr('disabled', true);
             breakButton.attr("disabled", false);
             stopLi.attr('disabled', false);
             options.runButton.empty();


### PR DESCRIPTION
1. Assign `role=application` to REPL container (`.repl`) so it's in Forms mode (suitable for higher-end screenreaders)
2. REPL expressions that produce no output should say so (instead of repeating the input expression)
3. Extraneous vertical space was showing up under toolbar on any window resize: remove it
4. Clicking any other top-level menuitem, whether expandable or not, should hide all (other) submenus
5. Disable Run Dropdown when Run has been clicked and is not yet finished
6. Clicking a disabled menuitem (e.g., Run Dropdown when Run is in effect) should not drop a submenu
7. When Run and Run Dropdown are disabled, their text should be grayed out 

In particular: 
- item 3 fixes #292
- items 5, 6 and 7 fix #291 

