### PR TITLE
Fix shadowing issue causing errors-when-rendering-errors not to render

### DIFF
--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -901,15 +901,15 @@
                       }, "highlightSrcloc, then help");
                     }, function(containerResult) {
                       if (runtime.isSuccessResult(containerResult)) {
-                        var container = containerResult.result;
-                        if (container.length > 0) {
-                          container = $("<div>").append(container);
+                        var resContainer = containerResult.result;
+                        if (resContainer.length > 0) {
+                          resContainer = $("<div>").append(resContainer);
                         }
-                        container.addClass("compile-error");
-                        container.append(renderStackTrace(runtime,documents, srcloc, richStack));
-                        restarter.resume(container);
+                        resContainer.addClass("compile-error");
+                        resContainer.append(renderStackTrace(runtime,documents, srcloc, richStack));
+                        restarter.resume(resContainer);
                       } else {
-                        container.add($("<span>").addClass("output-failed")
+                        container.append($("<span>").addClass("output-failed")
                                       .text("<error rendering reason for exception; details logged to console>"));
                         console.error("help: embed: highlightSrcloc or help failed:", errorDisp);
                         console.log(errorDisp.exn);
@@ -917,7 +917,7 @@
                       }
                     });
                   } else {
-                    container.add($("<span>").addClass("output-failed")
+                    container.append($("<span>").addClass("output-failed")
                                   .text("<error rendering fancy-reason of exception; details logged to console>"));
                     console.error("help: embed: render-fancy-reason failed:", errorDisp);
                     console.log(errorDisp.exn);


### PR DESCRIPTION
Sorry for the confusing title... this fixes a bug @blerner and I encountered yesterday. If there is a runtime bug in `error.arr`, when rendering that in the test, the output UI does not actually add the message saying that there was an error rendering the error

To reproduce, you can add runtime-error-causing code in a couple of `render-fancy-reason` methods, then call code invoking those errors.

I changed https://github.com/brownplt/pyret-lang/blob/horizon/src/arr/trove/error.arr#L904 to `left-loc = ast.bogus-field` and https://github.com/brownplt/pyret-lang/blob/horizon/src/arr/trove/error.arr#L1023 to `left-loc = S.dummy-loc`, which trigger the two cases in this UI change

and then ran:

```
check:
  1 + "" is 2
  1 * "" is 2
end
```

Before this fix, notice the empty red boxes:

<img width="694" alt="Screen Shot 2019-06-28 at 12 16 49 AM" src="https://user-images.githubusercontent.com/10344453/60316793-0efb1680-993a-11e9-8cb9-e61ea5234b0e.png">


After:

<img width="706" alt="Screen Shot 2019-06-28 at 12 05 16 AM" src="https://user-images.githubusercontent.com/10344453/60316556-048c4d00-9939-11e9-88aa-0131ebff0b9d.png">
