### PR TITLE
Add minor gridlines

### DIFF
--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -94,6 +94,10 @@ legend-method = method(self, legend :: String):
   self.constr()(self.obj.{legend: legend})
 end
 
+show-minor-grid-lines-method = method(self, is-showing :: Boolean):
+  self.constr()(self.obj.{show-minor-grid-lines: is-showing})
+end
+
 x-axis-method = method(self, x-axis :: String):
   self.constr()(self.obj.{x-axis: x-axis})
 end
@@ -344,6 +348,7 @@ type PlotChartWindowObject = {
 default-plot-chart-window-object :: PlotChartWindowObject = default-chart-window-object.{
   x-axis: '',
   y-axis: '',
+  show-minor-grid-lines: false,
   x-min: none,
   x-max: none,
   y-min: none,
@@ -443,6 +448,7 @@ data ChartWindow:
     y-max: y-max-method,
   | plot-chart-window(obj :: PlotChartWindowObject) with:
     constr: {(): plot-chart-window},
+    show-minor-grid-lines: show-minor-grid-lines-method,
     x-axis: x-axis-method,
     y-axis: y-axis-method,
     x-min: x-min-method,

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -182,6 +182,16 @@
     $.extend(options, {hAxis: hAxis, vAxis: vAxis});
   }
 
+  function gridlinesMutator(options, globalOptions, _) {
+    const hAxis = ('hAxis' in options) ? options.hAxis : {};
+    const vAxis = ('vAxis' in options) ? options.vAxis : {};
+    hAxis.minorGridlines = {color: '#ddd', minSpacing: 5};
+    vAxis.minorGridlines = {color: '#ddd', minSpacing: 5};
+    hAxis.gridlines = {color: '#aaa', minSpacing: 40};
+    vAxis.gridlines = {color: '#aaa', minSpacing: 40};
+    $.extend(options, {hAxis: hAxis, vAxis: vAxis});
+  }
+
   function yAxisRangeMutator(options, globalOptions, _) {
     const vAxis = ('vAxis' in options) ? options.vAxis : {};
     const viewWindow = ('viewWindow' in vAxis) ? vAxis.viewWindow : {};
@@ -563,7 +573,10 @@ ${labelRow}`;
           restarter,
           RUNTIME.ffi.makeRight)
       },
-      mutators: [axesNameMutator, yAxisRangeMutator, xAxisRangeMutator],
+      mutators: [axesNameMutator,
+                 yAxisRangeMutator,
+                 xAxisRangeMutator,
+                 gridlinesMutator],
       overlay: (overlay, restarter, chart, container) => {
         overlay.css({
           width: '30%',

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -185,10 +185,15 @@
   function gridlinesMutator(options, globalOptions, _) {
     const hAxis = ('hAxis' in options) ? options.hAxis : {};
     const vAxis = ('vAxis' in options) ? options.vAxis : {};
-    hAxis.minorGridlines = {color: '#ddd', minSpacing: 5};
-    vAxis.minorGridlines = {color: '#ddd', minSpacing: 5};
-    hAxis.gridlines = {color: '#aaa', minSpacing: 40};
-    vAxis.gridlines = {color: '#aaa', minSpacing: 40};
+    hAxis.gridlines = {color: '#aaa'};
+    vAxis.gridlines = {color: '#aaa'};
+    if (get(globalOptions, 'show-minor-grid-lines')) {
+      hAxis.minorGridlines = {color: '#ddd', minSpacing: 10};
+      vAxis.minorGridlines = {color: '#ddd', minSpacing: 10};
+    } else {
+      hAxis.minorGridlines = {count: 0};
+      vAxis.minorGridlines = {count: 0};
+    }
     $.extend(options, {hAxis: hAxis, vAxis: vAxis});
   }
 


### PR DESCRIPTION
Per @schanzer's request.

For example, for the program:

```
include chart
import color as C

fun some-fun(x): num-sin(2 * x) end
a-series = from-list.function-plot(some-fun)
  .color(C.purple)
a-chart-window = render-chart(a-series)

a-chart-window
  .x-axis("this is x-axis")
  .y-axis("this is y-axis")
  .display()
```

In CPO, it displays:

<img width="404" alt="Screen Shot 2020-11-28 at 14 25 43" src="https://user-images.githubusercontent.com/9099577/100527263-cfb3a380-3185-11eb-9d72-9998b634aa9d.png">

With this patch, it displays:

<img width="402" alt="Screen Shot 2020-11-28 at 14 27 01" src="https://user-images.githubusercontent.com/9099577/100527266-d80bde80-3185-11eb-8c02-a6505b9050f3.png">

Here's another example for the 10x + 7 graph:

<img width="404" alt="Screen Shot 2020-11-28 at 14 32 08" src="https://user-images.githubusercontent.com/9099577/100527342-89127900-3186-11eb-892f-25220c5f7d9a.png">

vs 

<img width="403" alt="Screen Shot 2020-11-28 at 14 35 02" src="https://user-images.githubusercontent.com/9099577/100527400-09d17500-3187-11eb-99cb-1ad6dccc64d0.png">

Notice that the number of lines in the minor grids are not the same (across chart / across axes). It might be possible to do that by using a right Google Charts configuration, but that's future work.