### PR TITLE
Move min and max to ChartWindow

### DIFF
--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -192,15 +192,11 @@ type BoxChartSeries = {
   tab :: TableIntern,
   height :: Number, 
   horizontal :: Boolean,
-  min :: Option<Number>,
-  max :: Option<Number>
 }
 
 default-box-plot-series = {
   horizontal: false,
   show-outliers: true,
-  min: none,
-  max: none
 }
 
 type PieChartSeries = {
@@ -287,12 +283,16 @@ type BoxChartWindowObject = {
   height :: Number,
   x-axis :: String,
   y-axis :: String,
+  min :: Option<Number>,
+  max :: Option<Number>,
   render :: ( -> IM.Image),
 }
 
 default-box-plot-chart-window-object :: BoxChartWindowObject = default-chart-window-object.{
   x-axis: '',
   y-axis: '',
+  min: none,
+  max: none,
 }
 
 type PieChartWindowObject = {
@@ -406,8 +406,6 @@ data DataSeries:
     method show-outliers(self, show):
       self.constr()(self.obj.{show-outliers: show})
     end,
-    min: min-method,
-    max: max-method,
   | histogram-series(obj :: HistogramSeries) with:
     is-single: true,
     constr: {(): histogram-series},

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -289,11 +289,10 @@
   }
 
   function boxPlot(globalOptions, rawData) {
-    var table = get(rawData, 'tab');
+    let table = get(rawData, 'tab');
     const dimension = toFixnum(get(rawData, 'height'));
+    // TODO: are these two supposed to be on ChartWindow or DataSeries?
     const horizontal = get(rawData, 'horizontal');
-    const min = get(rawData, 'min');
-    const max = get(rawData, 'max');
     const showOutliers = get(rawData, 'show-outliers');
     const axisName = horizontal ? 'hAxis' : 'vAxis';
     const chartType = horizontal ? google.visualization.BarChart : google.visualization.ColumnChart;
@@ -400,13 +399,13 @@
     /* NOTE(Emmanuel): if min and max are set, override these defaults
      * 
      */
-    cases(RUNTIME.ffi.isOption, 'Option', get(rawData, 'min'), {
+    cases(RUNTIME.ffi.isOption, 'Option', get(globalOptions, 'min'), {
       none: function () {},
       some: function (min) {
           axisOpts.viewWindow.min = toFixnum(min);
         }
     });
-    cases(RUNTIME.ffi.isOption, 'Option', get(rawData, 'max'), {
+    cases(RUNTIME.ffi.isOption, 'Option', get(globalOptions, 'max'), {
       none: function () {},
       some: function (max) {
           axisOpts.viewWindow.max = toFixnum(max);


### PR DESCRIPTION
Example:

```
include chart

the-box-plot = from-list.box-plot(
  [list: 
    [list: 1, 2, 3, 4], 
    [list: 1, 2, 3, 4, 5], 
    [list: 10, 11]])

render-chart(the-box-plot)
  .max(20)
  .display()
```

Please take over this PR if any further changes are needed.

CC: @schanzer @jpolitz