### PR TITLE
Improve UI for save as, rename, and import dialogs.

### DIFF
--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -2100,13 +2100,21 @@ table.choiceContainer {
 }
 div.choiceContainer {
    text-align: left;
+   margin-top: 16px;
 }
 div.choiceContainer input[type=text] {
+  display: block;
+  margin-top: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  font-family: var(--font-stack);
   padding: 0.5em;
   font-size: 100%;
-  border: 1px solid #999;
-  border-radius: 2px;
+  border: 1px solid #aaa;
+  border-radius: 3px;
 }
+
 div.choiceContainer .textLabel {
   margin-right: 1em;
 }
@@ -2194,7 +2202,7 @@ table.pyret-row {
 }
 
 .modal-content.narrow {
-  max-width: 500px;
+  max-width: 400px;
 }
 
 /* Add Animation */
@@ -2301,7 +2309,7 @@ table.pyret-row {
 }
 
 .modal-footer {
-  padding: 2px 20px 20px;
+  padding: 20px;
   display: flex;
   flex-direction: row-reverse;
 }

--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -2096,8 +2096,42 @@ table {
 
 table.choiceContainer {
    border: 0px;
-   margin: 1em;
+   margin: 0px;
+   background: none;
+   border-radius: 4px;
 }
+
+table.choiceContainer tr {
+  background: none !important;
+}
+table.choiceContainer td {
+  border-bottom: 1px solid #ccc;
+}
+table.choiceContainer tr:last-child td {
+  border-bottom-width: 0px;
+}
+table.choiceContainer .pyret-modal-option-example {
+  padding-right: 0px;
+}
+.pyret-modal-option-example .CodeMirror {
+  border: none;
+  background: transparent;
+  font-size: 90%;
+}
+
+/* make whole cell area occupied by clickable label */
+.modal td.pyret-modal-option-message {
+  padding: 0px;
+}
+
+.pyret-modal-option-message label {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  font-weight: bold;
+  color: var(--run-hover);
+}
+
 div.choiceContainer {
    text-align: left;
    margin-top: 16px;
@@ -2214,20 +2248,6 @@ table.pyret-row {
 @keyframes animatetop {
   from {top:-300px; opacity:0}
   to {top:0; opacity:1}
-}
-
-/* The Submit and Close Buttons */
-/*.modal .submit,
-.modal .close {
-  color: white;
-  font-size: 28px;
-  font-weight: bold;
-  padding: 10px 5px;
-}*/
-
-.modal table {
-  width: 90%;
-  margin: 0 5%;
 }
 
 .modal td {

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -631,10 +631,11 @@ $(function() {
       var saveAsPrompt = new modalPrompt({
         title: "Save a copy",
         style: "text",
+        submitText: "Save",
+        narrow: true,
         options: [
           {
             message: "The name for the copy:",
-            submitText: "Save",
             defaultValue: name
           }
         ]
@@ -656,6 +657,7 @@ $(function() {
       var renamePrompt = new modalPrompt({
         title: "Rename this file",
         style: "text",
+        narrow: true,
         options: [
           {
             message: "The new name for the file:",

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -683,7 +683,7 @@
       var photoPrompt = function(count) {
         var plural = count > 1;
         return new modalPrompt({
-          title: "Import type",
+          title: "Import options",
           style: "radio",
           submitText: "Import",
           cancelText: "Close",

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -868,7 +868,7 @@
         onError: flashError,
         onInternalError: stickError,
         views: ["imageView"],
-        title: "Select an image to use"
+        title: "Select images"
       });
 
       return runtime.makeModuleReturn({

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -680,29 +680,40 @@
         curImg = maxSoFar + 1;
       }
 
-      var photoPrompt = function() {
+      var photoPrompt = function(count) {
+        var plural = count > 1;
         return new modalPrompt({
-          title: "Select Import Style",
+          title: "Import type",
           style: "radio",
           submitText: "Import",
           cancelText: "Close",
           options: [
             {
-              message: "Import as Values",
+              message: "Value" + (plural ? "s" : ""),
               value: "values",
-              example: 'image-url("<URL>")\nimage-url("<URL>")\n# ...'
+              example: 'image-url("<URL>")'
+                + (plural ? '\n'
+                      + (count > 2 ? '# ' + (count-2) + ' more...\n': '')
+                      + 'image-url("<URL>")'
+                    : '')
             },
             {
-              message: "Import as Definitions",
+              message: "Definition" + (plural ? "s" : ""),
               value: "defs",
-              example: 'image0 = image-url("<URL>")\nimage1 = image-url("<URL>")\n# ...'
+              example: 'image' + (plural ? '0' : '') + ' = image-url("<URL>")'
+                + (plural ? 
+                      (count > 2 ? '\n# ' + (count-2) + ' more...' : '')
+                      + '\nimage' + (count-1) + ' = image-url("<URL>")'
+                    : '')
             },
             {
-              message: "Import as a List",
+              message: "List",
               value: "list",
-              example: '[list: image-url("<URL>"),\n'
-                + '       image-url("<URL>"),\n'
-                + '       # ...\n       ]'
+              example: '[list: image-url("<URL>")'
+                + (plural ? 
+                      ',\n' + (count > 2 ? '       # ' + (count-2) + ' more...\n' : '')
+                        + '       image-url("<URL>")]'
+                    : ']')
             }]
         });
       }
@@ -764,7 +775,7 @@
         else if (documents[0][picker.Document.TYPE] === picker.Type.PHOTO) {
 
           try {
-            photoPrompt().show(function(res) {
+            photoPrompt(documents.length).show(function(res) {
               // Name of event for CM undo history
               var origin = "+insertImage" + curImg;
               var asValues = (res === "values");

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -684,6 +684,8 @@
         return new modalPrompt({
           title: "Select Import Style",
           style: "radio",
+          submitText: "Import",
+          cancelText: "Close",
           options: [
             {
               message: "Import as Values",

--- a/src/web/js/modal-prompt.js
+++ b/src/web/js/modal-prompt.js
@@ -79,7 +79,7 @@ define("cpo/modal-prompt", ["q"], function(Q) {
     else {
       this.closeButton.text("Cancel");
     }
-    this.modalContent.toggleClass("narrow", this.options.narrow);
+    this.modalContent.toggleClass("narrow", !!this.options.narrow);
 
     this.isCompiled = false;
     this.deferred = Q.defer();

--- a/src/web/js/modal-prompt.js
+++ b/src/web/js/modal-prompt.js
@@ -173,7 +173,7 @@ define("cpo/modal-prompt", ["q"], function(Q) {
           value: option.example,
           mode: 'pyret',
           lineNumbers: false,
-          readOnly: true
+          readOnly: "nocursor" // this makes it readOnly & not focusable as a form input
         });
         setTimeout(function(){
           cm.refresh();

--- a/src/web/js/modal-prompt.js
+++ b/src/web/js/modal-prompt.js
@@ -64,6 +64,7 @@ define("cpo/modal-prompt", ["q"], function(Q) {
       this.elts = $($.parseHTML("<div></div>")).addClass("choiceContainer");
     }
     this.title = $(".modal-header > h3", this.modal);
+    this.modalContent = $(".modal-content", this.modal);
     this.closeButton = $(".close", this.modal);
     this.submitButton = $(".submit", this.modal);
     if(this.options.submitText) {
@@ -72,6 +73,14 @@ define("cpo/modal-prompt", ["q"], function(Q) {
     else {
       this.submitButton.text("Submit");
     }
+    if(this.options.cancelText) {
+      this.closeButton.text(this.options.cancelText);
+    }
+    else {
+      this.closeButton.text("Cancel");
+    }
+    this.modalContent.toggleClass("narrow", this.options.narrow);
+
     this.isCompiled = false;
     this.deferred = Q.defer();
     this.promise = this.deferred.promise;
@@ -120,6 +129,7 @@ define("cpo/modal-prompt", ["q"], function(Q) {
     this.title.text(this.options.title);
     this.populateModal();
     this.modal.css('display', 'block');
+    $(":input:enabled:visible:first", this.modal).focus().select()
 
     if (callback) {
       return this.promise.then(callback);
@@ -187,9 +197,9 @@ define("cpo/modal-prompt", ["q"], function(Q) {
 
     function createTextElt(option) {
       var elt = $("<div>");
-      elt.append($("<span>").addClass("textLabel").text(option.message));
+      elt.append($("<label for='modal-prompt-text'>").addClass("textLabel").text(option.message));
 //      elt.append($("<span>").text("(" + option.details + ")"));
-      elt.append($("<input type='text'>").val(option.defaultValue));
+      elt.append($("<input id='modal-prompt-text' type='text'>").val(option.defaultValue));
       return elt;
     }
 
@@ -241,7 +251,6 @@ define("cpo/modal-prompt", ["q"], function(Q) {
     $("input[type='radio']", optionElts[0]).attr('checked', true);
     this.elts.append(optionElts);
     $(".modal-body", this.modal).empty().append(this.elts);
-    optionElts[0].focus();
   };
 
   /**

--- a/src/web/js/share.js
+++ b/src/web/js/share.js
@@ -74,6 +74,7 @@ window.makeShareAPI = function makeShareAPI(pyretVersion) {
         title: "Publish this file",
         style: "confirm",
         submitText: "Publish",
+        narrow: true,
         options: [
           {
             message: "This program has not been shared before.  Publishing it by clicking below will make a new copy of the file that you can share with anyone you like.  They will be able to see your code and run your program."
@@ -83,6 +84,9 @@ window.makeShareAPI = function makeShareAPI(pyretVersion) {
       newShare.show().then(function(confirmed) {
         if(confirmed === true) {
           window.CPO.save().then(function(p) {
+            // TODO: this message may not be visible enough and there can be a
+            // lengthy delay between the first dialog closing and the next one
+            // opening. Might want to leave modal open with a spinner...
             window.stickMessage("Copying...");
             var copy = p.makeShareCopy();
             copy.fail(function(err) {


### PR DESCRIPTION
This PR improves UI styling, a11y, visual hierarchy, and some micro text for three of the CPO modal dialogs.

(After starting work on other modals, they require enough thinking that they need to be in separate PRs.)

# Scope

### Global dialog improvements
- [x] Dialogs can customize the text on the close button, default to "Cancel" (#350)
- [x] Focus the first focusable element after shown.
- [x] Allow dialogs to opt into narrower style.

### Individual dialogs
- [x] Save As / Rename
  - [x] Change submit button text to "Save"
  - [x] Narrower, clearer spacing
  - [ ] Suggest better/funnier name for unnamed files? Change "Untitled" suggestion to "avast.arr"?

- [x] Import image
  - [x] Clarify styling of the three separate options in the table
  - [x] Make code samples smarter, adjusting to number of files selected
  - [x] Find a better name for import image style picker. "Import type" could be mistaken for a PL "type". Need to convey "how do you want these images to be imported?"
  - [ ] Make more of each row clickable to select the radio button

# Preview 

## Save As / Rename

Production:
![image](https://user-images.githubusercontent.com/8495/119926289-aabfb200-bfa9-11eb-8ed4-f3fdbdc57b11.png)

With this PR:
![image](https://user-images.githubusercontent.com/8495/119926228-89f75c80-bfa9-11eb-9628-bacdcb8c0e4f.png)

## Import image

**Production:**
![image](https://user-images.githubusercontent.com/8495/119956079-474a7a00-bfd3-11eb-86e1-7f92ff622f67.png)
(Code samples show like this, even when only 1 or 2 files selected.)

**With this PR:**
Code samples change depending on number of files selected.
- e.g. with one file:
![image](https://user-images.githubusercontent.com/8495/119956433-ae682e80-bfd3-11eb-8049-87b1ca10ecc5.png)
- with three files:
![image](https://user-images.githubusercontent.com/8495/119955989-339f1380-bfd3-11eb-9312-852b1756397c.png)
