### PR TITLE
prevent scrollbars from causing REPL line height issues

### DIFF
--- a/src/web/css/themes/base16.css
+++ b/src/web/css/themes/base16.css
@@ -165,9 +165,7 @@ body.base16 {
   --loader-text:        var(--white);             /* text containing loading messages during page load */
 
   /* Scrollbars */
-  --scroll-bg:              var(--black-lighter-2);   /* scrollbar track background*/
-  --scroll-thumb:           var(--black-lighter-3);   /* scrollbar thumb */
-  --scroll-thumb-highlight: var(--black-lighter-4);   /* scrollbar thumb when hover */
+  --scrollbar-theme: dark;
 
   /* More granular control of check blocks */
   --check-success-text: var(--success-green);   /* text within successful check block */

--- a/src/web/css/themes/material-darker.css
+++ b/src/web/css/themes/material-darker.css
@@ -170,9 +170,7 @@ body.material-darker {
   --loader-text:          var(--white);               /* text containing loading messages during page load */
 
   /* Scrollbars */
-  --scroll-bg:              var(--black-lighter-2);   /* scrollbar track background*/
-  --scroll-thumb:           var(--black-lighter-3);   /* scrollbar thumb */
-  --scroll-thumb-highlight: var(--black-lighter-4);   /* scrollbar thumb when hover */
+  --scrollbar-theme: dark;
 
   /* More granular control of check blocks */
   --check-success-text: var(--success-green);     /* text within successful check block */

--- a/src/web/css/themes/monokai.css
+++ b/src/web/css/themes/monokai.css
@@ -165,9 +165,7 @@ body.monokai {
   --loader-text:      var(--white);               /* text containing loading messages during page load */
 
   /* Scrollbars */
-  --scroll-bg:              var(--black-lighter-2);   /* scrollbar track background*/
-  --scroll-thumb:           var(--black-lighter-3);   /* scrollbar thumb */
-  --scroll-thumb-highlight: var(--black-lighter-4);   /* scrollbar thumb when hover */
+  --scrollbar-theme: dark;
 
   /* More granular control of check blocks */
   --check-success-text: var(--success-green);   /* text within successful check block */

--- a/src/web/css/themes/non-default-overrides.css
+++ b/src/web/css/themes/non-default-overrides.css
@@ -94,32 +94,9 @@ body:not(.default) .CodeMirror div.CodeMirror-ruler {
   border-left-style: none !important;
 }
 
-/* scrollbar in CodeMirror elements */
-body:not(.default) .CodeMirror-vscrollbar::-webkit-scrollbar {
-  width: 15px;
-  background-color: var(--scroll-bg);
-}
-body:not(.default) .CodeMirror-vscrollbar::-webkit-scrollbar-thumb {
-  background-color: var(--scroll-thumb);
-  border-radius: 2px;
-}
-body:not(.default) .CodeMirror-vscrollbar::-webkit-scrollbar-thumb:hover {
-  background-color: var(--scroll-thumb-highlight);
-}
-
-/* scrollbars in the REPL */
-body:not(.default) #REPL ::-webkit-scrollbar { width: 15px; }
-body:not(.default) #REPL ::-webkit-scrollbar-track {
-  width: 15px;
-  background-color: var(--scroll-bg);
-}
-body:not(.default) #REPL ::-webkit-scrollbar-thumb {
-  background-color: var(--scroll-thumb);
-  border-radius: 2px;
-}
-body:not(.default) #REPL ::-webkit-scrollbar-thumb:hover {
-  background-color: var(--scroll-thumb-highlight);
-  cursor: pointer;
+/* scroll bar color */
+body:not(.default) .CodeMirror, body:not(.default) #REPL {
+  color-scheme: dark; 
 }
 
 /* summaries for passed/failed tests at top */

--- a/src/web/css/themes/non-default-overrides.css
+++ b/src/web/css/themes/non-default-overrides.css
@@ -96,7 +96,7 @@ body:not(.default) .CodeMirror div.CodeMirror-ruler {
 
 /* scroll bar color */
 body:not(.default) .CodeMirror, body:not(.default) #REPL {
-  color-scheme: dark; 
+  color-scheme: var(--scrollbar-theme); 
 }
 
 /* summaries for passed/failed tests at top */

--- a/src/web/css/themes/panda-syntax.css
+++ b/src/web/css/themes/panda-syntax.css
@@ -173,9 +173,7 @@ body.panda {
   --loader-text:          var(--white);               /* text containing loading messages during page load */
 
   /* Scrollbars */
-  --scroll-bg:              var(--black-lighter-2);   /* scrollbar track background*/
-  --scroll-thumb:           var(--black-lighter-3);   /* scrollbar thumb */
-  --scroll-thumb-highlight: var(--black-lighter-4);   /* scrollbar thumb when hover */
+  --scrollbar-theme: dark;
 
   /* More granular control of check blocks */
   --check-success-text: var(--success-green);   /* text within successful check block */

--- a/src/web/css/themes/template.css
+++ b/src/web/css/themes/template.css
@@ -132,9 +132,7 @@ body.template {
   --loader-text: gray;              /* text containing loading messages during page load */
 
   /* Scrollbars */
-  --scroll-bg: gray;               /* scrollbar track background*/
-  --scroll-thumb: gray;            /* scrollbar thumb */
-  --scroll-thumb-highlight: gray;  /* scrollbar thumb when hover */
+  --scrollbar-theme: dark;
 
   /* More granular control of check blocks */
   --check-success-text: gray; /* text within successful check block */


### PR DESCRIPTION
This addresses the line height problems mentioned in #377 by changing scrollbars in the non-default themes. 

Previously, they used the `::webkit-scrollbar` selectors to create a custom scrollbar for both the REPL and CodeMirror windows. We've switched to using the [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) property, which is only affecting the color of the scrollbar and seems reasonably well-supported.

We have checked Firefox, Brave, Chrome and Safari and so far the worst effect is that in Safari when switching between themes, the scrollbar maintains its previous color until you click on it. I would argue this is a better issue than line height problems that prevent the REPL from being readable.