### PR TITLE
Fix bug with editor/repl height

### DIFF
--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -723,7 +723,7 @@ $(function() {
   }
 
   function updateEditorHeight() {
-    var toolbarHeight = document.getElementById('topTierUl').scrollHeight;
+    var toolbarHeight = document.getElementById('topTierUl').offsetHeight;
     // gets bumped to 67 on initial resize perturbation, but actual value is indeed 40
     if (toolbarHeight < 80) toolbarHeight = 40;
     toolbarHeight += 'px';


### PR DESCRIPTION
This addresses the issue raised in #384.

The minimal change here was to use `offsetHeight` instead of `scrollHeight` so we no longer count the height of the absolutely-positioned menu.

A major question I have is in what case this code is needed at all. Seems like the same goal could likely be met in CSS and I don't understand in what case the toolbar is larger than the CSS size and requires running this code dynamically on all scroll/resize events. If someone can explain that, I'd be happy to take a crack at a more-complete solution.