### PR TITLE
Fix #387, unwanted spacing of multi-line REPL inputs

### DIFF
--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -901,7 +901,7 @@
         run: runner,
         initial: "",
         cmOptions: {
-          scrollPastEnd: true,
+          scrollPastEnd: false,
           extraKeys: CodeMirror.normalizeKeyMap({
             'Enter': function(cm) { runner(cm.getValue(), {cm: cm}); },
             'Shift-Enter': "newlineAndIndent",


### PR DESCRIPTION
This PR fixes the issue reported in #387.

😭 Sigh. I spent several hours on this and typed up an elaborate essay on why it was happening. There was a cool bit about some mathematical sleuthing (an arithmetic sequence of -11 + 16n extra pixels of padding per line of REPL input!), using a little-known Chrome DevTools feature (you can set JS breakpoints to occur whenever a node's `style` attribute is changed to see what code does it!), and a lecture about the merits of various ways to measure DOM nodes in various CSS contexts.

But the right fix is the one in this PR, that just turns off an unused plugin that was responsible for all of that nonsense.  The "scrollpastend" plugin is useful for CodeMirror instances that have a fixed height and should be scrollable inside the height, like the CPO definitions area. But the plugin was also turned on for the REPL input, where it isn't wanted, because we want the repl CodeMirror instance to expand in height automatically and then scroll within the scope of the broader repl history. Doing auto-expansion plus trying to add extra room to scroll within a (non-existent) fixed container caused all this unwanted extra space to be added. 