### PR TITLE
Performance: remove unused optional dependencies of node modules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,8 @@ libpyret:
 	$(MAKE) phaseA -C pyret/
 
 $(BUNDLED_DEPS): src/scripts/npm-dependencies.js
-	node_modules/.bin/browserify src/scripts/npm-dependencies.js -o $(BUNDLED_DEPS)
+	# Explicitly exclude crypto, buffer, and stylus, nested npm dependencies that aren't needed
+	node_modules/.bin/browserify src/scripts/npm-dependencies.js -x crypto -x buffer -x stylus -o $(BUNDLED_DEPS)
 
 $(CPOMAIN): $(BUNDLED_DEPS) $(TROVE_JS) $(TROVE_ARR) $(WEBJS) src/web/js/*.js src/web/arr/*.arr cpo-standalone.js cpo-config.json src/web/arr/cpo-main.arr $(PHASEA)
 	mkdir -p compiled/;

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "sha.js": "^2.4.8",
         "source-map": "^0.5.7",
         "style-loader": "0.13.1",
-        "stylus": "^0.54.5",
         "supervisor": "^0.11.0",
         "url-loader": "^0.6.2",
         "url.js": "^1.0.2",
@@ -1102,92 +1101,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/@types/node": {
-      "version": "10.14.13",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/ajv": {
-      "version": "6.10.2",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/ansi-escapes": {
-      "version": "4.2.1",
-      "extraneous": true,
-      "dependencies": {
-        "type-fest": "^0.5.2"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.5.2",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/chalk": {
-      "version": "2.4.1",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/debug": {
-      "version": "4.1.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/doctrine": {
-      "version": "3.0.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/eslint": {
-      "version": "6.7.2",
-      "extraneous": true,
-      "dependencies": {
-        "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "eslint-utils": "^1.4.3",
-        "file-entry-cache": "^5.0.1",
-        "globals": "^12.1.0",
-        "inquirer": "^7.0.0",
-        "lodash": "^4.17.14",
-        "optionator": "^0.8.3",
-        "semver": "^6.1.2",
-        "strip-json-comments": "^3.0.1"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/eslint-utils": {
-      "version": "1.4.3",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/eslint/node_modules/lodash": {
-      "version": "4.17.19",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/figures": {
-      "version": "3.0.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/file-entry-cache": {
-      "version": "5.0.1",
-      "extraneous": true,
-      "dependencies": {
-        "flat-cache": "^2.0.1"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/flat-cache": {
-      "version": "2.0.1",
-      "extraneous": true,
-      "dependencies": {
-        "write": "1.0.3"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/globals": {
-      "version": "12.3.0",
-      "extraneous": true
-    },
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/http-call": {
       "version": "5.2.4",
       "dependencies": {
@@ -1198,82 +1111,11 @@
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/http-call/node_modules/debug": {
       "version": "4.1.1"
     },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/inquirer": {
-      "version": "7.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^3.1.0",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
-        "string-width": "^4.1.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/inquirer/node_modules/chalk": {
-      "version": "2.4.2",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/inquirer/node_modules/lodash": {
-      "version": "4.17.19",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "extraneous": true
-    },
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/is-stream": {
       "version": "2.0.0"
     },
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/lodash": {
       "version": "4.17.20"
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/mute-stream": {
-      "version": "0.0.8",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/onetime": {
-      "version": "5.1.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/optionator": {
-      "version": "0.8.3",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "onetime": "^5.1.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/semver": {
-      "version": "6.3.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/string-width": {
-      "version": "4.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/strip-json-comments": {
-      "version": "3.0.1",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/tmp": {
-      "version": "0.0.33",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/tslib": {
-      "version": "1.9.3",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/write": {
-      "version": "1.0.3",
-      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-certs": {
       "version": "7.54.0",
@@ -1539,113 +1381,12 @@
     "node_modules/@heroku-cli/plugin-ci/node_modules/@sindresorhus/is": {
       "version": "0.14.0"
     },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/@types/node": {
-      "version": "10.14.13",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/ajv": {
-      "version": "6.10.2",
-      "extraneous": true
-    },
     "node_modules/@heroku-cli/plugin-ci/node_modules/cacheable-request": {
       "version": "6.0.0",
       "dependencies": {
         "http-cache-semantics": "^4.0.0",
         "keyv": "^3.0.0"
       }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/chalk": {
-      "version": "2.4.1",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/doctrine": {
-      "version": "3.0.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint": {
-      "version": "6.7.2",
-      "extraneous": true,
-      "dependencies": {
-        "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "eslint-utils": "^1.4.3",
-        "file-entry-cache": "^5.0.1",
-        "globals": "^12.1.0",
-        "inquirer": "^7.0.0",
-        "optionator": "^0.8.3",
-        "semver": "^6.1.2",
-        "strip-json-comments": "^3.0.1"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint-utils": {
-      "version": "1.4.3",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/ansi-escapes": {
-      "version": "4.2.1",
-      "extraneous": true,
-      "dependencies": {
-        "type-fest": "^0.5.2"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/debug": {
-      "version": "4.1.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/inquirer": {
-      "version": "7.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^3.1.0",
-        "figures": "^3.0.0",
-        "mute-stream": "0.0.8",
-        "string-width": "^4.1.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/inquirer/node_modules/chalk": {
-      "version": "2.4.2",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/semver": {
-      "version": "6.3.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/type-fest": {
-      "version": "0.5.2",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/figures": {
-      "version": "3.0.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/file-entry-cache": {
-      "version": "5.0.1",
-      "extraneous": true,
-      "dependencies": {
-        "flat-cache": "^2.0.1"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/flat-cache": {
-      "version": "2.0.1",
-      "extraneous": true,
-      "dependencies": {
-        "write": "1.0.3"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/globals": {
-      "version": "12.3.0",
-      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-ci/node_modules/got": {
       "version": "9.6.0",
@@ -1658,66 +1399,17 @@
     "node_modules/@heroku-cli/plugin-ci/node_modules/http-cache-semantics": {
       "version": "4.0.1"
     },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "extraneous": true
-    },
     "node_modules/@heroku-cli/plugin-ci/node_modules/keyv": {
       "version": "3.1.0"
     },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/mute-stream": {
-      "version": "0.0.8",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/nock": {
-      "version": "9.6.1",
-      "extraneous": true,
-      "dependencies": {
-        "debug": "^3.1.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/nock/node_modules/debug": {
-      "version": "3.2.6",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/onetime": {
-      "version": "5.1.0",
-      "extraneous": true
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/optionator": {
-      "version": "0.8.3",
-      "extraneous": true
-    },
     "node_modules/@heroku-cli/plugin-ci/node_modules/p-cancelable": {
       "version": "1.0.0"
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "onetime": "^5.1.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/string-width": {
-      "version": "4.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/strip-json-comments": {
-      "version": "3.0.1",
-      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-ci/node_modules/tmp": {
       "version": "0.0.33"
     },
     "node_modules/@heroku-cli/plugin-ci/node_modules/uuid": {
       "version": "8.3.0"
-    },
-    "node_modules/@heroku-cli/plugin-ci/node_modules/write": {
-      "version": "1.0.3",
-      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-config": {
       "version": "7.54.0",
@@ -8356,17 +8048,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -8395,22 +8076,6 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/css-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-      "dependencies": {
-        "css": "^2.0.0"
-      }
-    },
-    "node_modules/css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cssesc": {
@@ -14410,7 +14075,136 @@
       "version": "0.0.0",
       "resolved": "git+ssh://git@github.com/brownplt/pyret-lang.git#335f803c9fc3474ca1f1fcd6903533cebc248de9",
       "bundleDependencies": [
-        "browserify"
+        "browserify",
+        "acorn",
+        "acorn-node",
+        "acorn-walk",
+        "asn1.js",
+        "assert",
+        "balanced-match",
+        "base64-js",
+        "bn.js",
+        "brace-expansion",
+        "brorand",
+        "browser-pack",
+        "browser-resolve",
+        "browserify-aes",
+        "browserify-cipher",
+        "browserify-des",
+        "browserify-rsa",
+        "browserify-sign",
+        "browserify-zlib",
+        "buffer",
+        "buffer-from",
+        "buffer-xor",
+        "builtin-status-codes",
+        "cached-path-relative",
+        "cipher-base",
+        "combine-source-map",
+        "concat-map",
+        "concat-stream",
+        "console-browserify",
+        "constants-browserify",
+        "convert-source-map",
+        "core-util-is",
+        "create-ecdh",
+        "create-hash",
+        "create-hmac",
+        "crypto-browserify",
+        "dash-ast",
+        "defined",
+        "deps-sort",
+        "des.js",
+        "detective",
+        "diffie-hellman",
+        "domain-browser",
+        "duplexer2",
+        "elliptic",
+        "events",
+        "evp_bytestokey",
+        "fast-safe-stringify",
+        "fs.realpath",
+        "function-bind",
+        "get-assigned-identifiers",
+        "glob",
+        "has",
+        "hash-base",
+        "hash.js",
+        "hmac-drbg",
+        "htmlescape",
+        "https-browserify",
+        "ieee754",
+        "indexof",
+        "inflight",
+        "inherits",
+        "inline-source-map",
+        "insert-module-globals",
+        "is-buffer",
+        "isarray",
+        "json-stable-stringify",
+        "jsonify",
+        "jsonparse",
+        "JSONStream",
+        "labeled-stream-splicer",
+        "lodash.memoize",
+        "md5.js",
+        "miller-rabin",
+        "minimalistic-assert",
+        "minimalistic-crypto-utils",
+        "minimatch",
+        "minimist",
+        "module-deps",
+        "object-assign",
+        "once",
+        "os-browserify",
+        "pako",
+        "parents",
+        "parse-asn1",
+        "path-browserify",
+        "path-is-absolute",
+        "path-parse",
+        "path-platform",
+        "pbkdf2",
+        "process",
+        "process-nextick-args",
+        "public-encrypt",
+        "punycode",
+        "querystring",
+        "querystring-es3",
+        "randombytes",
+        "randomfill",
+        "read-only-stream",
+        "readable-stream",
+        "resolve",
+        "ripemd160",
+        "safe-buffer",
+        "sha.js",
+        "shasum",
+        "shasum-object",
+        "shell-quote",
+        "simple-concat",
+        "source-map",
+        "stream-browserify",
+        "stream-combiner2",
+        "stream-http",
+        "stream-splicer",
+        "string_decoder",
+        "subarg",
+        "syntax-error",
+        "through",
+        "through2",
+        "timers-browserify",
+        "to-arraybuffer",
+        "tty-browserify",
+        "typedarray",
+        "umd",
+        "undeclared-identifiers",
+        "url",
+        "util",
+        "util-deprecate",
+        "vm-browserify",
+        "wrappy",
+        "xtend"
       ],
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -16411,7 +16205,8 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -17360,54 +17155,6 @@
         "emojis-list": "^2.0.0",
         "json5": "^0.5.0",
         "object-assign": "^4.0.1"
-      }
-    },
-    "node_modules/stylus": {
-      "version": "0.54.8",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.8.tgz",
-      "integrity": "sha512-vr54Or4BZ7pJafo2mpf0ZcwA74rpuYCZbxrHBsH8kbcXOwSfvBFwsRfpGO5OD5fhG5HDCFW737PKaawI7OqEAg==",
-      "dependencies": {
-        "css-parse": "~2.0.0",
-        "debug": "~3.1.0",
-        "glob": "^7.1.6",
-        "mkdirp": "~1.0.4",
-        "safer-buffer": "^2.1.2",
-        "sax": "~1.2.4",
-        "semver": "^6.3.0",
-        "source-map": "^0.7.3"
-      },
-      "bin": {
-        "stylus": "bin/stylus"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/stylus/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/stylus/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stylus/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/subarg": {
@@ -19887,7 +19634,6 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -20454,96 +20200,6 @@
         "valid-url": "^1.0.9"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.14.13",
-          "extraneous": true
-        },
-        "ajv": {
-          "version": "6.10.2",
-          "extraneous": true
-        },
-        "ansi-escapes": {
-          "version": "4.2.1",
-          "extraneous": true,
-          "requires": {
-            "type-fest": "^0.5.2"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.5.2",
-              "extraneous": true
-            }
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "extraneous": true
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "extraneous": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.0",
-          "extraneous": true
-        },
-        "doctrine": {
-          "version": "3.0.0",
-          "extraneous": true
-        },
-        "eslint": {
-          "version": "6.7.2",
-          "extraneous": true,
-          "requires": {
-            "ajv": "^6.10.0",
-            "chalk": "^2.1.0",
-            "debug": "^4.0.1",
-            "doctrine": "^3.0.0",
-            "eslint-utils": "^1.4.3",
-            "file-entry-cache": "^5.0.1",
-            "globals": "^12.1.0",
-            "inquirer": "^7.0.0",
-            "lodash": "^4.17.14",
-            "optionator": "^0.8.3",
-            "semver": "^6.1.2",
-            "strip-json-comments": "^3.0.1"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.19",
-              "extraneous": true
-            }
-          }
-        },
-        "eslint-utils": {
-          "version": "1.4.3",
-          "extraneous": true
-        },
-        "figures": {
-          "version": "3.0.0",
-          "extraneous": true
-        },
-        "file-entry-cache": {
-          "version": "5.0.1",
-          "extraneous": true,
-          "requires": {
-            "flat-cache": "^2.0.1"
-          }
-        },
-        "flat-cache": {
-          "version": "2.0.1",
-          "extraneous": true,
-          "requires": {
-            "write": "1.0.3"
-          }
-        },
-        "globals": {
-          "version": "12.3.0",
-          "extraneous": true
-        },
         "http-call": {
           "version": "5.2.4",
           "requires": {
@@ -20556,84 +20212,11 @@
             }
           }
         },
-        "inquirer": {
-          "version": "7.0.0",
-          "extraneous": true,
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^3.1.0",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.15",
-            "mute-stream": "0.0.8",
-            "string-width": "^4.1.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "extraneous": true
-            },
-            "lodash": {
-              "version": "4.17.19",
-              "extraneous": true
-            }
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "extraneous": true
-        },
         "is-stream": {
           "version": "2.0.0"
         },
         "lodash": {
           "version": "4.17.20"
-        },
-        "mute-stream": {
-          "version": "0.0.8",
-          "extraneous": true
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "extraneous": true
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "extraneous": true
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "extraneous": true,
-          "requires": {
-            "onetime": "^5.1.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "extraneous": true
-        },
-        "string-width": {
-          "version": "4.1.0",
-          "extraneous": true,
-          "requires": {
-            "is-fullwidth-code-point": "^3.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "3.0.1",
-          "extraneous": true
-        },
-        "tmp": {
-          "version": "0.0.33",
-          "extraneous": true
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "extraneous": true
-        },
-        "write": {
-          "version": "1.0.3",
-          "extraneous": true
         }
       }
     },
@@ -20831,117 +20414,12 @@
         "@sindresorhus/is": {
           "version": "0.14.0"
         },
-        "@types/node": {
-          "version": "10.14.13",
-          "extraneous": true
-        },
-        "ajv": {
-          "version": "6.10.2",
-          "extraneous": true
-        },
         "cacheable-request": {
           "version": "6.0.0",
           "requires": {
             "http-cache-semantics": "^4.0.0",
             "keyv": "^3.0.0"
           }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "extraneous": true
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "extraneous": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "doctrine": {
-          "version": "3.0.0",
-          "extraneous": true
-        },
-        "eslint": {
-          "version": "6.7.2",
-          "extraneous": true,
-          "requires": {
-            "ajv": "^6.10.0",
-            "chalk": "^2.1.0",
-            "debug": "^4.0.1",
-            "doctrine": "^3.0.0",
-            "eslint-utils": "^1.4.3",
-            "file-entry-cache": "^5.0.1",
-            "globals": "^12.1.0",
-            "inquirer": "^7.0.0",
-            "optionator": "^0.8.3",
-            "semver": "^6.1.2",
-            "strip-json-comments": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "4.2.1",
-              "extraneous": true,
-              "requires": {
-                "type-fest": "^0.5.2"
-              }
-            },
-            "debug": {
-              "version": "4.1.0",
-              "extraneous": true
-            },
-            "inquirer": {
-              "version": "7.0.0",
-              "extraneous": true,
-              "requires": {
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^2.4.2",
-                "cli-cursor": "^3.1.0",
-                "figures": "^3.0.0",
-                "mute-stream": "0.0.8",
-                "string-width": "^4.1.0"
-              },
-              "dependencies": {
-                "chalk": {
-                  "version": "2.4.2",
-                  "extraneous": true
-                }
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "extraneous": true
-            },
-            "type-fest": {
-              "version": "0.5.2",
-              "extraneous": true
-            }
-          }
-        },
-        "eslint-utils": {
-          "version": "1.4.3",
-          "extraneous": true
-        },
-        "figures": {
-          "version": "3.0.0",
-          "extraneous": true
-        },
-        "file-entry-cache": {
-          "version": "5.0.1",
-          "extraneous": true,
-          "requires": {
-            "flat-cache": "^2.0.1"
-          }
-        },
-        "flat-cache": {
-          "version": "2.0.1",
-          "extraneous": true,
-          "requires": {
-            "write": "1.0.3"
-          }
-        },
-        "globals": {
-          "version": "12.3.0",
-          "extraneous": true
         },
         "got": {
           "version": "9.6.0",
@@ -20954,68 +20432,17 @@
         "http-cache-semantics": {
           "version": "4.0.1"
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "extraneous": true
-        },
         "keyv": {
           "version": "3.1.0"
         },
-        "mute-stream": {
-          "version": "0.0.8",
-          "extraneous": true
-        },
-        "nock": {
-          "version": "9.6.1",
-          "extraneous": true,
-          "requires": {
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "extraneous": true
-            }
-          }
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "extraneous": true
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "extraneous": true
-        },
         "p-cancelable": {
           "version": "1.0.0"
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "extraneous": true,
-          "requires": {
-            "onetime": "^5.1.0"
-          }
-        },
-        "string-width": {
-          "version": "4.1.0",
-          "extraneous": true,
-          "requires": {
-            "is-fullwidth-code-point": "^3.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "3.0.1",
-          "extraneous": true
         },
         "tmp": {
           "version": "0.0.33"
         },
         "uuid": {
           "version": "8.3.0"
-        },
-        "write": {
-          "version": "1.0.3",
-          "extraneous": true
         }
       }
     },
@@ -21474,7 +20901,6 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -21896,7 +21322,6 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -22274,7 +21699,6 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -22668,10 +22092,8 @@
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.18.tgz",
       "integrity": "sha512-sfLb5UUCwyQ0w9LyQ1/3DUuD/RWnPZk6uvcK5P7pqD65WgRJaOPCqzuNZyb56kPsj6FftRp1UudApNKd7U0KBQ==",
       "requires": {
-        "@oclif/config": "^1",
         "@oclif/errors": "^1.2.2",
         "@oclif/parser": "^3.8.3",
-        "@oclif/plugin-help": "^2",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
       },
@@ -22813,7 +22235,6 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -23281,7 +22702,6 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -26403,24 +25823,6 @@
         "uid-safe": "2.1.5"
       }
     },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -26439,14 +25841,6 @@
         "postcss-value-parser": "^4.1.0",
         "schema-utils": "^2.7.0",
         "semver": "^6.3.0"
-      }
-    },
-    "css-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-      "requires": {
-        "css": "^2.0.0"
       }
     },
     "cssesc": {
@@ -32717,7 +32111,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "schema-utils": {
       "version": "2.7.1",
@@ -33473,41 +32868,6 @@
             "json5": "^0.5.0",
             "object-assign": "^4.0.1"
           }
-        }
-      }
-    },
-    "stylus": {
-      "version": "0.54.8",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.8.tgz",
-      "integrity": "sha512-vr54Or4BZ7pJafo2mpf0ZcwA74rpuYCZbxrHBsH8kbcXOwSfvBFwsRfpGO5OD5fhG5HDCFW737PKaawI7OqEAg==",
-      "requires": {
-        "css-parse": "~2.0.0",
-        "debug": "~3.1.0",
-        "glob": "^7.1.6",
-        "mkdirp": "~1.0.4",
-        "safer-buffer": "^2.1.2",
-        "sax": "~1.2.4",
-        "semver": "^6.3.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "sha.js": "^2.4.8",
     "source-map": "^0.5.7",
     "style-loader": "0.13.1",
-    "stylus": "^0.54.5",
     "supervisor": "^0.11.0",
     "url-loader": "^0.6.2",
     "url.js": "^1.0.2",

--- a/src/scripts/npm-dependencies.js
+++ b/src/scripts/npm-dependencies.js
@@ -2,6 +2,11 @@
 // When building a web-standalone, browserify will parse this file
 // and produce a version which include each dependency that is required()
 //
+// Unfortunately some of these libraries have optional transitive dependencies
+// that are enormous and unused, so we need to prevent them from getting bundled.
+// See the browserify options in the Makefile, which currently prevent the 
+// crypto, buffer, and stylus libraries from being bundled, saving ~700kb.
+
 sexpr = require("s-expression");
 define("s-expression", [], function() {return sexpr;});
 


### PR DESCRIPTION
Several of the node packages we bundle have _optional_ dependencies that are currently being bundled, but not used, taking up ~700kb of space in the built version of `npm-dependencies.js` that gets packaged with `cpo-main.jarr`.

This change directs browserify to explicitly not bundle those packages.

Examples:
- `colorspaces` is a 10kb library for color math. It [_optionally_ pulls in stylus](https://github.com/boronine/colorspaces.js/blob/master/colorspaces.js#L324), in order to offer some helpers to people who use it. We currently bundle the whole stylus compiler code (400kb) and never use it.
- `js-md5` and `js-sha256` are small, pure-js implementations of their respective functions. But [they](https://github.com/emn178/js-md5/blob/0263ab835f4847351a710f98488203108c0e1e90/src/md5.js#L155) [also](https://github.com/emn178/js-sha256/blob/189bb9b03782b80e59516dfbea78f16b5d9754ce/src/sha256.js#L83) optionally pull in node modules that offer faster versions of their features when run on the server. As a result, we are currently bundling node's `crypto` and `buffer` implementations and not using them. (~300kb).

Because these optional imports are in the source of dependencies, I was unable to remove them surgically and instead have just instructed browserify to _never_ include them. If we ever _do_ want to use those packages, we'll need to undo this change. (But, also, we have probably made a mistake.)