### PR TITLE
Performance: strip JavaScript comments from cpo-main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,8 @@ $(CPOMAIN): $(BUNDLED_DEPS) $(TROVE_JS) $(TROVE_ARR) $(WEBJS) src/web/js/*.js sr
 # NOTE(joe): Need to do .gz.js because Firefox doesn't like gzipped JS having a
 # non-.js extension.
 $(CPOGZ): $(CPOMAIN)
-	gzip -c -f $(CPOMAIN) > $(CPOGZ)
+	npm exec -- uglifyjs --compress -o $(CPOMAIN).min -- $(CPOMAIN)
+	gzip -c -f $(CPOMAIN).min > $(CPOGZ)
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
⚠️ Because this branch needs `uglifyjs`, it is built on top of the work #393. That PR should be reviewed and land before this one. The only changes to review here are in 40497f04f391c317580aa14408d2610c32e8c1c1.

I'm still figuring out the whole build process, but somehow the `cpo-main.jarr` file contains the raw text of some JavaScript packages we depend on, like `source-map`. By including the raw source, we are even including somewhere around 3mb of inline documentation from these packages. By running uglify over the source, we remove these unused bits.