### PR TITLE
Performance: make cpo-main smaller by trimming unneeded sourcemaps and minifying compiled code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,8 @@ $(CPOMAIN): $(BUNDLED_DEPS) $(TROVE_JS) $(TROVE_ARR) $(WEBJS) src/web/js/*.js sr
 # NOTE(joe): Need to do .gz.js because Firefox doesn't like gzipped JS having a
 # non-.js extension.
 $(CPOGZ): $(CPOMAIN)
-	gzip -c -f $(CPOMAIN) > $(CPOGZ)
+	npm exec -- uglifyjs --compress -o $(CPOMAIN).min -- $(CPOMAIN)
+	gzip -c -f $(CPOMAIN).min > $(CPOGZ)
 
 clean:
 	rm -rf build/

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,8 @@ $(CPOMAIN): $(BUNDLED_DEPS) $(TROVE_JS) $(TROVE_ARR) $(WEBJS) src/web/js/*.js sr
 # NOTE(joe): Need to do .gz.js because Firefox doesn't like gzipped JS having a
 # non-.js extension.
 $(CPOGZ): $(CPOMAIN)
-	npm exec -- uglifyjs --compress -o $(CPOMAIN).min -- $(CPOMAIN)
+	node src/scripts/trim-cpo-main.js $(CPOMAIN) > $(CPOMAIN).trim
+	npm exec -- uglifyjs --compress -o $(CPOMAIN).min -- $(CPOMAIN).trim
 	gzip -c -f $(CPOMAIN).min > $(CPOGZ)
 
 clean:

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
       },
       "devDependencies": {
         "chromedriver": "^90.0.0",
+        "escodegen": "^2.0.0",
         "selenium-webdriver": "^3.6.0",
         "webpack-cli": "^3.1.2"
       },
@@ -8704,6 +8705,47 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -26368,6 +26410,34 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "eslint": {
       "version": "6.8.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "chromedriver": "^90.0.0",
+    "escodegen": "^2.0.0",
     "selenium-webdriver": "^3.6.0",
     "webpack-cli": "^3.1.2"
   }

--- a/src/scripts/trim-cpo-main.js
+++ b/src/scripts/trim-cpo-main.js
@@ -1,0 +1,87 @@
+let acorn = require("acorn");
+let walk = require("acorn-walk");
+let escodegen = require("escodegen");
+let fs = require("fs");
+
+/*
+
+## Description
+
+This script is run during the production build to reduce the size of the cpo-main bundle.
+
+It walks the AST of the bundle looking for the compiled versions of internal modules
+(like the compiler implementation) and transforms them in two ways:
+
+1. It strips the source map (`theMap`), which can be quite large. While sourcemaps are used for some
+    error messages, end-users of CPO should never get source locations pointing to compiler
+    internals, so we do not need them for these modules.
+
+2. It inlines strings containing JavaScript code (in `theModule`), parsing them and then inserting them
+    into this document's AST. (Like a ,@ macro in Lisp.) The string version of the code has comments,
+    unnecessarily-long variable names, whitespace, etc. By replacing the string with JS code, we allow the
+    JS minifier (which runs at a later step) to reformat the code and make it ~50% smaller.
+
+## Example
+
+Before:
+
+```
+define("program", [deps], function() {
+    return {
+        "staticModules": {
+            // ... lots more modules ...,
+            "builtin://ast": ({
+                "theMap": "{\"version\":3, /* 300kb of sourcemap... } ",
+                "theModule": "function _5485(){ 200kb of function js as a string ... }",
+                "nativeRequires": [],
+                "provides": { ... }
+            })
+        }
+    };
+}
+```
+
+After:
+
+```
+define("program", [deps], function() {
+    return {
+        "staticModules": {
+            // ... lots more modules ...,
+            "builtin://ast": ({
+                "theMap": "",
+                "theModule": function _5485(){ js now inline as code ... },
+                "nativeRequires": [],
+                "provides": { ... }
+            })
+        }
+    };
+}
+```
+
+*/
+
+let file = process.argv[2]
+
+let ast = acorn.parse(fs.readFileSync(file));
+
+walk.simple(ast, {
+    Property(node) {
+        // FIXME: need to only run this on internal modules by inspecting module name.
+
+        if(node.key.value === "theModule" || node.key.name === "theModule") {
+            if(node.value.type === "Literal") {
+                let fnAst = acorn.parse(node.value.value);
+                node.value = fnAst;
+            }
+        }
+        if(node.key.value === "theMap" || node.key.name === "theMap") {
+            if(node.value.type === "Literal") {
+                node.value.value = "{}"
+                node.value.raw = "\"{}\""
+            }
+        }
+    }
+});
+
+process.stdout.write(escodegen.generate(ast));

--- a/src/scripts/trim-cpo-main.js
+++ b/src/scripts/trim-cpo-main.js
@@ -69,12 +69,12 @@ walk.simple(ast, {
     Property(node) {
         // FIXME: need to only run this on internal modules by inspecting module name.
 
-        if(node.key.value === "theModule" || node.key.name === "theModule") {
-            if(node.value.type === "Literal") {
-                let fnAst = acorn.parse(node.value.value);
-                node.value = fnAst;
-            }
-        }
+        // if(node.key.value === "theModule" || node.key.name === "theModule") {
+        //     if(node.value.type === "Literal") {
+        //         let fnAst = acorn.parse(node.value.value);
+        //         node.value = fnAst;
+        //     }
+        // }
         if(node.key.value === "theMap" || node.key.name === "theMap") {
             if(node.value.type === "Literal") {
                 node.value.value = "{}"


### PR DESCRIPTION
⚠️ This is not ready to be merged. It currently runs over _all_ compiled modules, when it should only run over compiler internals. Adam is adding this PR to start discussion and to see if tests break.

See the lengthy description inline in the code.

On my machine, this reduces the unminified code from 32mb to 19mb, and the gzipped version from 5.3mb to 3.7mb. (This difference will get _slightly_ smaller when we add back in sourcemaps for userland libraries, but not much. The vast majority of the code is internals.)

This builds on top of the work in #396 to minify cpo-main, which needs to land first. So changes for discussion here start at 58dcaad.