### PR TITLE
Performance: prefetch cpo-main

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -103,6 +103,7 @@ function start(config, onServerReady) {
   app.get("/", function(req, res) {
     var content = loggedIn(req) ? "My Programs" : "Log In";
     res.render("index.html", {
+      PYRET: process.env.PYRET,
       LEFT_LINK: content,
       GOOGLE_API_KEY: config.google.apiKey,
       BASE_URL: config.baseUrl,
@@ -315,6 +316,7 @@ function start(config, onServerReady) {
 
   app.get("/editor", function(req, res) {
     res.render("editor.html", {
+      PYRET: process.env.PYRET,
       BASE_URL: config.baseUrl,
       GOOGLE_API_KEY: config.google.apiKey,
       CSRF_TOKEN: req.csrfToken(),

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -3,6 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>code.pyret.org</title>
+  <link rel="preload" href="{{&PYRET}}" as="script">
   <link rel="stylesheet" href="/css/reset.css" />
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:400,700" />

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -5,6 +5,7 @@
     <title>code.pyret.org</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/img/pyret-icon.png">
+    <link rel="prefetch" href="{{&PYRET}}" as="script">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
     <!-- Used to w/Google for OAuth verification -->
@@ -12,7 +13,6 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
-    <script src="/js/codemirror.js"></script>
     <script src="/js/q.js"></script>
     <script src="/js/require.js"></script>
     

--- a/src/web/js/log.js
+++ b/src/web/js/log.js
@@ -102,31 +102,32 @@ var logger = (function(backend) {
   };
 })( LOG_URL ? new AJAXBackend(LOG_URL) : new DummyBackend() );
 
-
-CodeMirror.defineOption('logging', false, 
-  function (cm, new_value) {
-    if (new_value != true)
-      return;
-    if(!cm.CPO_editorID)
-      cm.CPO_editorID = logger.guid();
-    logger.log('cm_init', {CPO_editorID: cm.CPO_editorID});
-    cm.on("change", function(cm, change) {
-      if(logger.isDetailed) {
-        change.CPO_editorID = cm.CPO_editorID;
-        logger.log('cm_change', change);
-      }
+if(window.CodeMirror) {
+  CodeMirror.defineOption('logging', false, 
+    function (cm, new_value) {
+      if (new_value != true)
+        return;
+      if(!cm.CPO_editorID)
+        cm.CPO_editorID = logger.guid();
+      logger.log('cm_init', {CPO_editorID: cm.CPO_editorID});
+      cm.on("change", function(cm, change) {
+        if(logger.isDetailed) {
+          change.CPO_editorID = cm.CPO_editorID;
+          logger.log('cm_change', change);
+        }
+      });
+      cm.on("focus", function(cm) {
+        if(logger.isDetailed) {
+          logger.log('cm_focus', {CPO_editorID: cm.CPO_editorID});
+        }
+      });
+      cm.on("blur", function(cm) {
+        if(logger.isDetailed) {
+          logger.log('cm_blur',  {CPO_editorID: cm.CPO_editorID});
+        }
+      });
     });
-    cm.on("focus", function(cm) {
-      if(logger.isDetailed) {
-        logger.log('cm_focus', {CPO_editorID: cm.CPO_editorID});
-      }
-    });
-    cm.on("blur", function(cm) {
-      if(logger.isDetailed) {
-        logger.log('cm_blur',  {CPO_editorID: cm.CPO_editorID});
-      }
-    });
-  });
+}
 
 // Log the loading of the logger (near the begining of page load)  
 logger.log('load');


### PR DESCRIPTION
# Context
CPO should be faster. Currently, the major blocker to rendering the CPO editor is waiting on the download of cpo-main.jarr. We're working on reducing the network/parse size of that file in e.g. #397. But it's also helpful to make sure we start this most-urgent request earlier in the process. Today, visitors view the dashboard, click into the editor, and have to load a bunch of the editor's CSS and JS before we even start trying to download cpo-main. 

# Changes
This PR aims to improve that by doing three things:
1. Add a [prefetch](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/prefetch) instruction for cpo-main on the dashboard page. This tells the browser we will want the file on the next page view and could it please download that file in the background once it has some free time. (This happens _after_ the current page is already loaded, so it doesn't slow down the current process.)
2. Add a [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) instruction for cpo-main on the editor page. This tells the browser we need the file urgently for the current page view and it should start downloading it immediately and at high priority. This lets cpo-main skip to the front of the queue, whereas today it currently doesn't get fetched until partway through the execution of beforePyret.js, which itself is only loaded after a number of stylesheets and other scripts.
3. (Side quest) In the process of adding the change to the dashboard, I noticed most of the dashboard's network time is spent downloading `CodeMirror`, which we don't actually use on the page. The only reason it seems to be loaded is that `log.js` is loaded on the page and references the `CodeMirror` global variable to configure some things. So I made `log.js` able to tolerate CodeMirror not being on the page and then removed it.

# Review notes
- This PR is stacked on top of #393 because it needs some of the same templating changes made there. The real changes for this PR start in https://github.com/brownplt/code.pyret.org/commit/c00ed92c9ed6eea67682d5d49129e975d3545dd1
- The prefetch/preload bits should be completely safe, as the browser is free to ignore them and just fetch the file as it did previously if anything goes wrong.