### PR TITLE
fix table borders in Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "code.pyret.org",
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1101,6 +1102,92 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/@types/node": {
+      "version": "10.14.13",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/ajv": {
+      "version": "6.10.2",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/ansi-escapes": {
+      "version": "4.2.1",
+      "extraneous": true,
+      "dependencies": {
+        "type-fest": "^0.5.2"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.5.2",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/chalk": {
+      "version": "2.4.1",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/debug": {
+      "version": "4.1.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/doctrine": {
+      "version": "3.0.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/eslint": {
+      "version": "6.7.2",
+      "extraneous": true,
+      "dependencies": {
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-utils": "^1.4.3",
+        "file-entry-cache": "^5.0.1",
+        "globals": "^12.1.0",
+        "inquirer": "^7.0.0",
+        "lodash": "^4.17.14",
+        "optionator": "^0.8.3",
+        "semver": "^6.1.2",
+        "strip-json-comments": "^3.0.1"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/eslint-utils": {
+      "version": "1.4.3",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/eslint/node_modules/lodash": {
+      "version": "4.17.19",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/figures": {
+      "version": "3.0.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/file-entry-cache": {
+      "version": "5.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/flat-cache": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "write": "1.0.3"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/globals": {
+      "version": "12.3.0",
+      "extraneous": true
+    },
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/http-call": {
       "version": "5.2.4",
       "dependencies": {
@@ -1111,11 +1198,82 @@
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/http-call/node_modules/debug": {
       "version": "4.1.1"
     },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/inquirer": {
+      "version": "7.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.1.0",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/inquirer/node_modules/chalk": {
+      "version": "2.4.2",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/inquirer/node_modules/lodash": {
+      "version": "4.17.19",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "extraneous": true
+    },
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/is-stream": {
       "version": "2.0.0"
     },
     "node_modules/@heroku-cli/plugin-buildpacks/node_modules/lodash": {
       "version": "4.17.20"
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/onetime": {
+      "version": "5.1.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/optionator": {
+      "version": "0.8.3",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "onetime": "^5.1.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/semver": {
+      "version": "6.3.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/string-width": {
+      "version": "4.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/strip-json-comments": {
+      "version": "3.0.1",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/tmp": {
+      "version": "0.0.33",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/tslib": {
+      "version": "1.9.3",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-buildpacks/node_modules/write": {
+      "version": "1.0.3",
+      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-certs": {
       "version": "7.54.0",
@@ -1381,12 +1539,113 @@
     "node_modules/@heroku-cli/plugin-ci/node_modules/@sindresorhus/is": {
       "version": "0.14.0"
     },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/@types/node": {
+      "version": "10.14.13",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/ajv": {
+      "version": "6.10.2",
+      "extraneous": true
+    },
     "node_modules/@heroku-cli/plugin-ci/node_modules/cacheable-request": {
       "version": "6.0.0",
       "dependencies": {
         "http-cache-semantics": "^4.0.0",
         "keyv": "^3.0.0"
       }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/chalk": {
+      "version": "2.4.1",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/doctrine": {
+      "version": "3.0.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint": {
+      "version": "6.7.2",
+      "extraneous": true,
+      "dependencies": {
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-utils": "^1.4.3",
+        "file-entry-cache": "^5.0.1",
+        "globals": "^12.1.0",
+        "inquirer": "^7.0.0",
+        "optionator": "^0.8.3",
+        "semver": "^6.1.2",
+        "strip-json-comments": "^3.0.1"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint-utils": {
+      "version": "1.4.3",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/ansi-escapes": {
+      "version": "4.2.1",
+      "extraneous": true,
+      "dependencies": {
+        "type-fest": "^0.5.2"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/debug": {
+      "version": "4.1.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/inquirer": {
+      "version": "7.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.1.0",
+        "figures": "^3.0.0",
+        "mute-stream": "0.0.8",
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/inquirer/node_modules/chalk": {
+      "version": "2.4.2",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/semver": {
+      "version": "6.3.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/eslint/node_modules/type-fest": {
+      "version": "0.5.2",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/figures": {
+      "version": "3.0.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/file-entry-cache": {
+      "version": "5.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/flat-cache": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "write": "1.0.3"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/globals": {
+      "version": "12.3.0",
+      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-ci/node_modules/got": {
       "version": "9.6.0",
@@ -1399,17 +1658,66 @@
     "node_modules/@heroku-cli/plugin-ci/node_modules/http-cache-semantics": {
       "version": "4.0.1"
     },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "extraneous": true
+    },
     "node_modules/@heroku-cli/plugin-ci/node_modules/keyv": {
       "version": "3.1.0"
     },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/nock": {
+      "version": "9.6.1",
+      "extraneous": true,
+      "dependencies": {
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/nock/node_modules/debug": {
+      "version": "3.2.6",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/onetime": {
+      "version": "5.1.0",
+      "extraneous": true
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/optionator": {
+      "version": "0.8.3",
+      "extraneous": true
+    },
     "node_modules/@heroku-cli/plugin-ci/node_modules/p-cancelable": {
       "version": "1.0.0"
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "onetime": "^5.1.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/string-width": {
+      "version": "4.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/strip-json-comments": {
+      "version": "3.0.1",
+      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-ci/node_modules/tmp": {
       "version": "0.0.33"
     },
     "node_modules/@heroku-cli/plugin-ci/node_modules/uuid": {
       "version": "8.3.0"
+    },
+    "node_modules/@heroku-cli/plugin-ci/node_modules/write": {
+      "version": "1.0.3",
+      "extraneous": true
     },
     "node_modules/@heroku-cli/plugin-config": {
       "version": "7.54.0",
@@ -19634,6 +19942,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
+            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -20200,6 +20509,96 @@
         "valid-url": "^1.0.9"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.14.13",
+          "extraneous": true
+        },
+        "ajv": {
+          "version": "6.10.2",
+          "extraneous": true
+        },
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "extraneous": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.5.2",
+              "extraneous": true
+            }
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "extraneous": true
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "extraneous": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "extraneous": true
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "extraneous": true
+        },
+        "eslint": {
+          "version": "6.7.2",
+          "extraneous": true,
+          "requires": {
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-utils": "^1.4.3",
+            "file-entry-cache": "^5.0.1",
+            "globals": "^12.1.0",
+            "inquirer": "^7.0.0",
+            "lodash": "^4.17.14",
+            "optionator": "^0.8.3",
+            "semver": "^6.1.2",
+            "strip-json-comments": "^3.0.1"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.19",
+              "extraneous": true
+            }
+          }
+        },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "extraneous": true
+        },
+        "figures": {
+          "version": "3.0.0",
+          "extraneous": true
+        },
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "extraneous": true,
+          "requires": {
+            "flat-cache": "^2.0.1"
+          }
+        },
+        "flat-cache": {
+          "version": "2.0.1",
+          "extraneous": true,
+          "requires": {
+            "write": "1.0.3"
+          }
+        },
+        "globals": {
+          "version": "12.3.0",
+          "extraneous": true
+        },
         "http-call": {
           "version": "5.2.4",
           "requires": {
@@ -20212,11 +20611,84 @@
             }
           }
         },
+        "inquirer": {
+          "version": "7.0.0",
+          "extraneous": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "string-width": "^4.1.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "extraneous": true
+            },
+            "lodash": {
+              "version": "4.17.19",
+              "extraneous": true
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "extraneous": true
+        },
         "is-stream": {
           "version": "2.0.0"
         },
         "lodash": {
           "version": "4.17.20"
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "extraneous": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "extraneous": true
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "extraneous": true
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "extraneous": true,
+          "requires": {
+            "onetime": "^5.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "extraneous": true
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "extraneous": true,
+          "requires": {
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "extraneous": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "extraneous": true
+        },
+        "tslib": {
+          "version": "1.9.3",
+          "extraneous": true
+        },
+        "write": {
+          "version": "1.0.3",
+          "extraneous": true
         }
       }
     },
@@ -20414,12 +20886,117 @@
         "@sindresorhus/is": {
           "version": "0.14.0"
         },
+        "@types/node": {
+          "version": "10.14.13",
+          "extraneous": true
+        },
+        "ajv": {
+          "version": "6.10.2",
+          "extraneous": true
+        },
         "cacheable-request": {
           "version": "6.0.0",
           "requires": {
             "http-cache-semantics": "^4.0.0",
             "keyv": "^3.0.0"
           }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "extraneous": true
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "extraneous": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "extraneous": true
+        },
+        "eslint": {
+          "version": "6.7.2",
+          "extraneous": true,
+          "requires": {
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-utils": "^1.4.3",
+            "file-entry-cache": "^5.0.1",
+            "globals": "^12.1.0",
+            "inquirer": "^7.0.0",
+            "optionator": "^0.8.3",
+            "semver": "^6.1.2",
+            "strip-json-comments": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "4.2.1",
+              "extraneous": true,
+              "requires": {
+                "type-fest": "^0.5.2"
+              }
+            },
+            "debug": {
+              "version": "4.1.0",
+              "extraneous": true
+            },
+            "inquirer": {
+              "version": "7.0.0",
+              "extraneous": true,
+              "requires": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^2.4.2",
+                "cli-cursor": "^3.1.0",
+                "figures": "^3.0.0",
+                "mute-stream": "0.0.8",
+                "string-width": "^4.1.0"
+              },
+              "dependencies": {
+                "chalk": {
+                  "version": "2.4.2",
+                  "extraneous": true
+                }
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "extraneous": true
+            },
+            "type-fest": {
+              "version": "0.5.2",
+              "extraneous": true
+            }
+          }
+        },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "extraneous": true
+        },
+        "figures": {
+          "version": "3.0.0",
+          "extraneous": true
+        },
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "extraneous": true,
+          "requires": {
+            "flat-cache": "^2.0.1"
+          }
+        },
+        "flat-cache": {
+          "version": "2.0.1",
+          "extraneous": true,
+          "requires": {
+            "write": "1.0.3"
+          }
+        },
+        "globals": {
+          "version": "12.3.0",
+          "extraneous": true
         },
         "got": {
           "version": "9.6.0",
@@ -20432,17 +21009,68 @@
         "http-cache-semantics": {
           "version": "4.0.1"
         },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "extraneous": true
+        },
         "keyv": {
           "version": "3.1.0"
         },
+        "mute-stream": {
+          "version": "0.0.8",
+          "extraneous": true
+        },
+        "nock": {
+          "version": "9.6.1",
+          "extraneous": true,
+          "requires": {
+            "debug": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "extraneous": true
+            }
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "extraneous": true
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "extraneous": true
+        },
         "p-cancelable": {
           "version": "1.0.0"
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "extraneous": true,
+          "requires": {
+            "onetime": "^5.1.0"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "extraneous": true,
+          "requires": {
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "extraneous": true
         },
         "tmp": {
           "version": "0.0.33"
         },
         "uuid": {
           "version": "8.3.0"
+        },
+        "write": {
+          "version": "1.0.3",
+          "extraneous": true
         }
       }
     },
@@ -20901,6 +21529,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
+            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -21322,6 +21951,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
+            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -21699,6 +22329,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
+            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -22092,8 +22723,10 @@
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.18.tgz",
       "integrity": "sha512-sfLb5UUCwyQ0w9LyQ1/3DUuD/RWnPZk6uvcK5P7pqD65WgRJaOPCqzuNZyb56kPsj6FftRp1UudApNKd7U0KBQ==",
       "requires": {
+        "@oclif/config": "^1",
         "@oclif/errors": "^1.2.2",
         "@oclif/parser": "^3.8.3",
+        "@oclif/plugin-help": "^2",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
       },
@@ -22235,6 +22868,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
+            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",
@@ -22702,6 +23336,7 @@
           "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "requires": {
+            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",

--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -2162,7 +2162,6 @@ table {
     width: 100%;
     table-layout: auto;
     display: table!important;
-    border:1px var(--table-border) solid;
     border-radius:1em;
     overflow:hidden;
     background:var(--table-bg);
@@ -2267,6 +2266,16 @@ table.pyret-table th,
 table.pyret-table td {
   border-right: 1px var(--pyret-table-col-dividers) solid;
   border-bottom: 1px var(--pyret-table-row-dividers) solid;
+}
+
+table.pyret-table td:last-child,
+table.pyret-table th:last-child {
+  border-right: none;
+}
+
+/* tds in the last row don't have bottom borders */
+table.pyret-table tr:last-child td {
+  border-bottom: none;
 }
 
 table.pyret-table thead {

--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -2268,13 +2268,15 @@ table.pyret-table td {
   border-bottom: 1px var(--pyret-table-row-dividers) solid;
 }
 
+/* td/th that are in last column don't have right borders */
 table.pyret-table td:last-child,
 table.pyret-table th:last-child {
   border-right: none;
 }
 
-/* tds in the last row don't have bottom borders */
-table.pyret-table tr:last-child td {
+/* td/th in the last row don't have bottom borders */
+table.pyret-table tr:last-child td,
+table.pyret-table tr:last-child th {
   border-bottom: none;
 }
 

--- a/src/web/css/themes/base16.css
+++ b/src/web/css/themes/base16.css
@@ -116,7 +116,6 @@ body.base16 {
   --summary-err-left-border:  var(--white);             /* vertical border left of error announcement in summary */
 
   /* Tables */
-  --table-border:       var(--black-lighter-3);    /* border on tables */
   --table-bg:           var(--black-lighter);      /* bg on tables */
   --table-even-rows-bg: var(--black-lighter-2);    /* bg on even rows in table */
   --th-bg:              var(--black-darker);       /* bg on table headers */

--- a/src/web/css/themes/default.css
+++ b/src/web/css/themes/default.css
@@ -77,7 +77,6 @@ body.default {
   --summary-err-left-border: hsl(0, 100%, 100%);  /* vertical border left of error announcement in summary */
 
   /* Tables */
-  --table-border: black;          /* border on tables */
   --table-bg: #eee;               /* bg on tables */
   --table-even-rows-bg: #f2f2f2;  /* bg on even rows in table */
   --th-bg: #ddd;                  /* bg on table headers */

--- a/src/web/css/themes/high-contrast-dark.css
+++ b/src/web/css/themes/high-contrast-dark.css
@@ -126,7 +126,6 @@ body.high-contrast-dark {
   --summary-err-left-border:  var(--black);             /* vertical border left of error announcement in summary */
 
   /* Tables */
-  --table-border:       var(--white);             /* border on tables */
   --table-bg:           var(--black-lighter);     /* bg on tables */
   --table-even-rows-bg: var(--black-lighter-2);   /* bg on even rows in table */
   --th-bg:              var(--black);             /* bg on table headers */

--- a/src/web/css/themes/high-contrast-light.css
+++ b/src/web/css/themes/high-contrast-light.css
@@ -101,7 +101,6 @@ body.high-contrast-light {
   --summary-err-left-border: black;               /* vertical border left of error announcement in summary */
 
   /* Tables */
-  --table-border: black;          /* border on tables */
   --table-bg: #eee;               /* bg on tables */
   --table-even-rows-bg: #f2f2f2;  /* bg on even rows in table */
   --th-bg: #ddd;                  /* bg on table headers */

--- a/src/web/css/themes/material-darker.css
+++ b/src/web/css/themes/material-darker.css
@@ -121,7 +121,6 @@ body.material-darker {
   --summary-err-left-border:  var(--white);             /* vertical border left of error announcement in summary */
 
   /* Tables */
-  --table-border:       var(--black-lighter-4);   /* border on tables */
   --table-bg:           var(--black-lighter);     /* bg on tables */
   --table-even-rows-bg: var(--black-lighter-2);   /* bg on even rows in table */
   --th-bg:              var(--black-darker);      /* bg on table headers */

--- a/src/web/css/themes/monokai.css
+++ b/src/web/css/themes/monokai.css
@@ -116,7 +116,6 @@ body.monokai {
   --summary-err-left-border:  var(--white);             /* vertical border left of error announcement in summary */
 
   /* Tables */
-  --table-border:       var(--black-lighter-4);   /* border on tables */
   --table-bg:           var(--black-lighter);     /* bg on tables */
   --table-even-rows-bg: var(--black-lighter-2);   /* bg on even rows in table */
   --th-bg:              var(--black);             /* bg on table headers */

--- a/src/web/css/themes/panda-syntax.css
+++ b/src/web/css/themes/panda-syntax.css
@@ -124,7 +124,6 @@ body.panda {
   --summary-err-left-border:  var(--white);             /* vertical border left of error announcement in summary */
 
   /* Tables */
-  --table-border:       var(--black-lighter-4);   /* border on tables */
   --table-bg:           var(--black-lighter);     /* bg on tables */
   --table-even-rows-bg: var(--black-lighter-2);   /* bg on even rows in table */
   --th-bg:              var(--black-darker);      /* bg on table headers */


### PR DESCRIPTION
For whatever reason tables have a rectangular border in Firefox.

![with-border](https://user-images.githubusercontent.com/13399527/135552517-bfb8fb32-a4bc-49f0-b600-95c95f14be93.png)

I only noticed because I accidentally set the table border to be black for the default theme. This PR removes that border so that tables are consistent across browsers, but still allows themes to control the internal borders between table cells.