### PR TITLE
Fix font size menu item

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -82,6 +82,7 @@ function start(config, onServerReady) {
   app.engine('html', mustache());
   app.engine('js', mustache());
   app.set('view engine', ['html', 'js']);
+  app.set('view cache', process.env.NODE_ENV !== 'development');
 
   app.get("/current-version", function(req, res) {
     res.status(200);

--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -1096,25 +1096,14 @@ body.smallHeader .replContainer {
   background-color: var(--info-button-hover);
 }
 
-div#font{
-  min-width: 180px;
-  border: 1px solid var(--shadow-lighter);
-  border-left: 0px;
-  border-right: 0px;
-  background:var(--shadow-lighter);
-  padding: 0px;
+#font {
+  padding: 5px 30px;
+  display: flex;
+  justify-content: space-between;
 }
 
-div#font:hover{
-  background:var(--shadow-lighter);
-  box-shadow: none;
-}
-
-#font div{
-  margin:0;
-  padding: 10px 0px;
-  text-align:center;
-  display: inline-block;
+#font div,
+#font button {
   font-family:var(--ui-font-stack);
   -webkit-touch-callout: none;
   -webkit-user-select: none; /* Webkit */
@@ -1122,26 +1111,24 @@ div#font:hover{
   -ms-user-select: none;   /* IE 10  */
   -o-user-select: none;
   user-select: none;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
-#font-plus{
-  width: 20%;
-  cursor: pointer;
+#font #font-label {
+  flex: 1;
 }
 
-#font-minus{
-  width: 20%;
-  cursor: pointer;
+#font #font-plus,
+#font #font-minus {
+  padding-left: 10px;
+  padding-right: 10px;
+  border: 1px solid var(--default-border);
+  border-radius: 4px;
+  text-align: center;
+  margin-left: 12px;
 }
 
-#font-label{
-  width: calc(60% - 2px);
-  cursor: default;
-  padding: 10px 5px;
-  border: 1px solid var(--shadow-lighter);
-  border-top:none;
-  border-bottom:none;
-}
 
 div#font-label:hover{
   background:none;

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -185,7 +185,10 @@
               </div>
             </li>
             <li role="presentation">
-              <div id="font"><div id="font-minus">-</div><div id="font-label">Font</div><div id="font-plus">+</div>
+              <div id="font">
+                <div id="font-label"></div>
+                <button type="button" id="font-minus">-</button>
+                <button type="button" id="font-plus">+</button>
               </div>
             </li>
             <li id="theme" role="presentation" style="white-space: nowrap;">

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -474,9 +474,15 @@
         }
         editor.refresh();
         replWidget.refresh();
-        $('#font-label').text("Font (" + $('#main').css("font-size") + ")");
+        updateFontSizeMenuText();
       }
-      $('#font-label').text("Font (" + $('#main').css("font-size") + ")");
+      function formatFontSizeMenuText(size) {
+        return "Font size: " + Math.round(parseFloat(size));
+      }
+      function updateFontSizeMenuText() {
+        $('#font-label').text(formatFontSizeMenuText($('#main').css("font-size")));
+      }
+      updateFontSizeMenuText();
 
       var curTheme = document.getElementById("theme-select").value;
       var themeSelect = $("#theme-select");


### PR DESCRIPTION
This PR does a few small tweaks to improve the font size menu item:

![2022-04-30 21 46 47 localhost 2e56d3a8d36f](https://user-images.githubusercontent.com/8495/166128683-93282ff4-6ade-461c-af7d-d98943cf7a56.png)

- Changes the menu item to styled more like normal items, as previous gray color led some users to believe it was disabled/inaccessible, and rearrange buttons closer to each other so experimentation is faster.
- Uses flexbox layout rather than some fixed widths based on occasionally-wrong math to avoid a few cases where the menu wrapped onto multiple lines.
- Fixes a bug where Safari sometimes showed long decimal font sizes (e.g. "10.1094854857px")
- Changes +/- from divs to buttons, so they are slightly more accessible for folks using assistive technology. (Though not massively, and I expect to try to fix some larger menu a11y issues soon)

Unrelated to this core change, and possibly cherry-pickable into its own branch, I have turned off the cacheing of css and html files that was being done by the mustache template engine, which meant you sometimes had to restart the whole server to see html changes, even after rebuilding assets manually.