### PR TITLE
Fix #472: repeating decimal overline bar rendering

### DIFF
--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -477,6 +477,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket-region {
 
 div.trace {
   overflow-x: auto;
+  padding-top: 1px;
 }
 div.trace.error {
    background-color: var(--trace-err-bg);


### PR DESCRIPTION
In #472, there was speculation the overline bar was rendering too thin. But the real issue is that the `.trace` container is cutting off vertical overflow, and current math means only a small fraction of the overline is visible, which gets not rendered on some display sizes/configurations.

This is a very conservative change, to just include an extra pixel of top padding to let the overline render. (There are more principled ways to do this, but without knowing what bad cases the `.trace {overflow-x: auto; }` was solving, I didn't want to touch them.)