### PR TITLE
smol mode fix

### DIFF
--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -1676,10 +1676,16 @@ body.smallHeader #handle {
 }
 
 #runButton, #breakButton {
-  min-width: 180px;
   padding-left: 30px;
   padding-right: 30px;
   box-shadow: 0px -5px 5px 1px var(--shadow-color);
+}
+
+
+@media only screen and (min-width: 700px) {
+  #runButton, #breakButton {
+    min-width: 180px;
+  }
 }
 
 body.smallHeader #runButton, body.smallHeader #breakButton {


### PR DESCRIPTION
Fix for #442.

<img width="546" alt="image" src="https://github.com/brownplt/code.pyret.org/assets/8495/762d74ed-b44e-43e3-b4d9-4122c50cea5b">

UI previously broke at widths <700px. Now works down to ~550px. The run and break buttons are rendered narrower under 700px.

We should do a more principled cleanup to make the menu layout work nicely on mobile devices, but this is easy/fast.