### PR TITLE
- Allow interval charts to compose w/other charts that render-charts() takes

### DIFF
--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -2013,7 +2013,7 @@ fun interval-chart-from-list(
   xs.each(check-num)
   ys.each(check-num)
   deltas.each(check-num)
-  yprimes = map2(lam(y, delta): y + delta end, ys, deltas)
+  yprimes = map2(lam(y, delta): y - delta end, ys, deltas)
   ys_farthest = map2(lam(y, yprime):
       if (y < 0) and (yprime < 0) and (yprime < y): yprime
       else if (y > 0) and (yprime > 0) and (yprime > y): yprime

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1139,7 +1139,7 @@
     const data = new google.visualization.DataTable();
     data.addColumn('number', 'X');
     const combined = scatters.concat(lines).concat(intervals);
-    console.log('combined is', combined);
+    // console.log('combined is', combined);
     const legends = [];
     let cnt = 1;
     const legendEnabled = combined.length > 1;
@@ -1156,14 +1156,14 @@
       data.addColumn({id: 'i1', type: 'number', role: 'interval'});
     });
 
-    console.log('legends is', legends);
-    console.log('data I is', data);
+    // console.log('legends is', legends);
+    // console.log('data I is', data);
 
     combined.forEach((p, i) => {
-      console.log('Ncols is', combined.length * 4);
+      // console.log('Ncols is', combined.length * 4);
       const rowTemplate = new Array(combined.length * 4 + 1).fill(null);
       const intervalP = (i >= minIntervalIndex);
-      console.log('rOwTemplate is', rowTemplate);
+      // console.log('rowTemplate is', rowTemplate);
       if (!intervalP) {
         data.addRows(get(p, 'ps').map(row => {
           // console.log('this row is', row);
@@ -1210,11 +1210,7 @@
       };
     });
 
-
-    console.log('row setting done');
-
-
-
+    // console.log('row setting done');
 
     // ASSERT: if we're using custom images, *every* series will have idx 3 defined
     const hasImage = combined.every(p => get(p, 'ps').filter(p => p[3]).length > 0);
@@ -1291,7 +1287,7 @@
     };
 
     if (lines.length != 0) {
-      console.log('setting line options');
+      // console.log('setting line options');
       const line0 = lines[0];
       const curveType = get(line0, 'curved');
       const lineWidth = toFixnum(get(line0, 'lineWidth'));
@@ -1310,45 +1306,6 @@
         options['lineDashStyle'] = dashlineStyle;
       }
     }
-
-    if (intervals.length != 0) {
-      console.log('setting interval options');
-      const interval0 = intervals[0];
-      options['curveType'] = 'function';
-      options['lineWidth'] = 0;
-      options['intervals'] = {
-        style: 'sticks',
-        lineWidth: 2,
-      };
-      let intervalStyle = get(interval0, 'style');
-      let intervalStickColor = get_default_color(interval0);
-      let intervalStickWidth = toFixnum(get(interval0, 'stick-width'));
-      let intervalFillOpacity = (intervalStyle == 'boxes') ? 0 : 1;
-      let intervalPointColor = get_pointer_color(interval0);
-      let intervalPointSize = toFixnum(get(interval0, 'point-size'));
-
-      options['interval'] = {
-          'i0': {
-            'style': intervalStyle,
-            'color': intervalStickColor,
-            'lineWidth': intervalStickWidth,
-            'barWidth': 0,
-            'pointSize': 0,
-            'fillOpacity': intervalFillOpacity,
-          },
-          'i1': {
-            'style': intervalStyle,
-            'color': intervalPointColor,
-            'pointSize': intervalPointSize,
-            'barWidth': 0,
-            'lineWidth': 4,
-            'fillOpacity': intervalFillOpacity,
-          },
-      };
-
-      console.log('interval options are', options);
-    }
-
 
     const ser0 = combined[0];
 

--- a/test-util/pyret-programs/charts/interval-chart-test.arr
+++ b/test-util/pyret-programs/charts/interval-chart-test.arr
@@ -36,10 +36,21 @@ ser-some-ys-all-ress-rough = from-list.interval-chart(xs, some-ys-rough, all-res
 
 ser-all-ys-all-ress-rough = from-list.interval-chart(xs, all-ys-rough, all-ress-rough)
 
+# Other types of charts
+
+fn = lam(x): (x * x) - 1 end
+
+scatter-ser = from-list.scatter-plot(xs, ys)
+fn-ser = from-list.function-plot(fn)
+
 # Helper function
 
 fun render-image(series):
   render-chart(series).get-image()
+end
+
+fun render-composite-image(list-of-series):
+  render-charts(list-of-series).get-image()
 end
 
 # Actual testing
@@ -98,4 +109,13 @@ check "Exceptions":
   from-list.interval-chart(empty, empty, empty) raises "need at least one datum"
   from-list.interval-chart(xs, too-few-ys, ress) raises "xs and ys should have the same length"
   from-list.interval-chart(xs, ys, too-few-ress) raises "deltas should have the same length as xs and ys"
+end
+
+check "Render multiple charts":
+  render-composite-image([list: ser-no-rough]) satisfies is-image
+  render-composite-image([list: ser-no-rough, scatter-ser]) satisfies is-image
+  render-composite-image([list: ser-no-rough, fn-ser]) satisfies is-image
+  render-composite-image([list: scatter-ser, fn-ser]) satisfies is-image
+  render-composite-image([list: ser-no-rough, scatter-ser, fn-ser]) satisfies is-image
+  render-composite-image([list: ]) raises "need at least one series to plot"
 end


### PR DESCRIPTION
 #486
- chart-lib.js: Have plot() recognize and process interval charts, instead of having separate intervalChart()
- chart.arr: Rewrite render-charts() to accept interval-chart-series. For this, make interval-chart-series closer in properties to function/line/scatter series. interval-chart-from-list() now must keep track of the largest y's (including offset) so render-charts() can create a better bounding box. render-chart() no longer needs to do anything special with interval-charts, passing them on to render-charts()