### PR TITLE
Attempting to trim chart output upon saving

### DIFF
--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -25,7 +25,8 @@
     },
     { "import-type": "builtin",
       name: "load-lib"
-    }
+    },
+    { "import-type": "builtin", "name": "image-lib" }
   ],
   nativeRequires: [
     "pyret-base/js/runtime-util"
@@ -34,7 +35,7 @@
   theModule: function(runtime, _, uri,
                       checkUI, outputUI, errorUI,
                       textHandlers, replHistory,
-                      worldLib, loadLib,
+                      worldLib, loadLib, imageLib,
                       util) {
     var ffi = runtime.ffi;
 
@@ -314,41 +315,6 @@
           CM.focus();
         }
       });
-
-      function trimCanvas(canvas) {
-        function rowBlank(imageData, width, y) {
-          for (var x = 0; x < width; ++x) {
-            if (imageData.data[y * width * 4 + x * 4 + 3] !== 0) return false;
-          }
-          return true;
-        }
-
-        function columnBlank(imageData, width, x, top, bottom) {
-          for (var y = top; y < bottom; ++y) {
-            if (imageData.data[y * width * 4 + x * 4 + 3] !== 0) return false;
-          }
-          return true;
-        }
-
-        var ctx = canvas.getContext("2d");
-        var width = canvas.width;
-        var imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-        var top = 0, bottom = imageData.height, left = 0, right = imageData.width;
-
-        while (top < bottom && rowBlank(imageData, width, top)) ++top;
-        while (bottom - 1 > top && rowBlank(imageData, width, bottom - 1)) --bottom;
-        while (left < right && columnBlank(imageData, width, left, top, bottom)) ++left;
-        while (right - 1 > left && columnBlank(imageData, width, right - 1, top, bottom)) --right;
-
-        var trimmed = ctx.getImageData(left, top, right - left, bottom - top);
-        var copy = canvas.ownerDocument.createElement("canvas");
-        var copyCtx = copy.getContext("2d");
-        copy.width = trimmed.width;
-        copy.height = trimmed.height;
-        copyCtx.putImageData(trimmed, 0, 0);
-
-        return copy;
-      }
       
       function maybeShowOutputPending() {
         outputPendingHidden = false;
@@ -491,7 +457,8 @@
               temp.height = img.height;
               const ctx = temp.getContext('2d');
               ctx.drawImage(img, 0, 0);
-              const trimmed = trimCanvas(temp);
+              const image = runtime.getField(imageLib, "internal");
+              const trimmed = image.trimCanvas(temp);
               const download = document.createElement('a');
               download.href = trimmed.toDataURL();
               download.download = 'chart.png';

--- a/src/web/js/trove/internal-image-typed.js
+++ b/src/web/js/trove/internal-image-typed.js
@@ -144,6 +144,7 @@
       "radial-star": ["arrow", ["Number", "Number", "Number", "FillMode", "Color"], "Image"],
       "star-polygon": ["arrow", ["Number", "Number", "Number", "FillMode", "Color"], "Image"],
       "rhombus": ["arrow", ["Number", "Number", "FillMode", "Color"], "Image"],
+      "trim-image": ["arrow", ["Image"], "Image"],
       "image-to-color-list": ["arrow", ["Image"], "LoC"],
       "color-list-to-image": ["arrow", ["LoC", "Number", "Number", "Number", "Number"], "Image"],
       "color-at-position": ["arrow", ["Image", "Number", "Number"], "Color"],

--- a/src/web/js/trove/internal-image-untyped.js
+++ b/src/web/js/trove/internal-image-untyped.js
@@ -134,6 +134,7 @@
       "radial-star": ["arrow", ["Number", "Number", "Number", "FillMode", "ColorString"], "Image"],
       "star-polygon": ["arrow", ["Number", "Number", "Number", "FillMode", "ColorString"], "Image"],
       "rhombus": ["arrow", ["Number", "Number", "FillMode", "ColorString"], "Image"],
+      "trim-image": ["arrow", ["Image"], "Image"],
       "image-to-color-list": ["arrow", ["Image"], "LoC"],
       "color-list-to-image": ["arrow", ["LoC", "Number", "Number", "Number", "Number"], "Image"],
       "color-at-position": ["arrow", ["Image", "Number", "Number"], "Color"],

--- a/src/web/js/trove/make-image.js
+++ b/src/web/js/trove/make-image.js
@@ -1110,9 +1110,22 @@
           image.makeRhombusImage(length, angle, mode, color));
       });
 
+      f("trim-image", function(maybeImage) {
+        checkArity(1, arguments, "trim-image", false);
+        c1("trim-image", maybeImage, annImage);
+        var img = unwrapImage(maybeImage);
+        var canvas = image.trimImageToCanvas(img);
+        if (canvas.width === 0 || canvas.height === 0) {
+          return makeImage(
+            image.makeRectangleImage(canvas.width, canvas.height, "solid", colorDb.get("transparent")));
+        }
+        return makeImage(
+          image.makeImageDataImage(canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height)));
+      });
+
       f("image-to-color-list", function(maybeImage) {
         checkArity(1, arguments, "image-to-color-list", false);
-        c1("image-width", maybeImage, annImage);
+        c1("image-to-color-list", maybeImage, annImage);
         var img = unwrapImage(maybeImage);
         return image.imageToColorList(img);
       });
@@ -1142,7 +1155,6 @@
         checkArity(1, arguments, "image-pinhole-x", false);
         c1("image-pinhole-x", maybeImg, annImage);
         var img = unwrapImage(maybeImg);
-        debugger
         return runtime.wrap(img.getPinholeX());
       });
 
@@ -1150,7 +1162,6 @@
         checkArity(1, arguments, "image-pinhole-y", false);
         c1("image-pinhole-y", maybeImg, annImage);
         var img = unwrapImage(maybeImg);
-        debugger
         return runtime.wrap(img.getPinholeY());
       });
 
@@ -1188,6 +1199,9 @@
         }
         var pinholeX = jsnums.toFixnum(maybePinholeX);
         var pinholeY = jsnums.toFixnum(maybePinholeY);
+        if (width === 0 || height === 0) {
+          return makeImage(image.makeRectangleImage(width, height, "solid", colorDb.get("transparent")));
+        }
         return makeImage(image.colorListToImage(loc, width, height, pinholeX, pinholeY));
       });
 

--- a/test-util/pyret-programs/images/image-tests.arr
+++ b/test-util/pyret-programs/images/image-tests.arr
@@ -141,6 +141,27 @@ check "color-lists":
 
   color-list-to-bitmap([list: red, green, blue], 2, 2) raises ""
   color-list-to-bitmap([list: red, green, blue, black], 2, 2) satisfies is-image
+
+  color-list-to-image([list: ], 0, 0, 0, 0) does-not-raise
+end
+
+check "trimming":
+  sqr = square(40, "solid", red)
+  image-width(sqr) is 40
+  trim-image(sqr) satisfies is-image
+  image-width(trim-image(sqr)) is 40
+  image-height(sqr) is 40
+  image-height(trim-image(sqr)) is 40
+
+  blank = rectangle(40, 20, "solid", "transparent")
+  image-width(blank) is 40
+  trim-image(blank) satisfies is-image
+  image-width(trim-image(blank)) is 0
+  image-height(blank) is 20
+  image-height(trim-image(blank)) is 0
+
+  trim-image(trim-image(blank)) satisfies is-image
+
 end
 
 check "properties":


### PR DESCRIPTION
Uses https://gist.github.com/timdown/021d9c8f2aabc7092df564996f5afbbf to detect and eliminate transparent border pixels.  Note that this only works when saving the original image -- if you close the chart display window, and then view the output image again, it'll have the transparent border pixels again, and right-click saving that image will not trim them away.

Before:
![image](https://github.com/brownplt/code.pyret.org/assets/918464/cce94bd2-645b-4502-abb0-6a57efa36e3d)

After:
![chart](https://github.com/brownplt/code.pyret.org/assets/918464/54e769f2-0f03-4d58-b9be-275f12c9f836)
