### PR TITLE
Blocks error highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Then you can run
 ```
 $ npm run local-install
 $ ln -s node_modules/pyret-lang pyret
+$ git submodule init
+$ git submodule update
 $ npm run build
 ```
 

--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -1090,25 +1090,18 @@
                   logger.log("highlight_anchor_hover",
                     { error_id: context, anchor_id: id });
 
-                  // Blocks editor case
-                  if(CPO.blocksIDE) {
-                    if(positions.length > 0) {
+                  if (positions[0] !== undefined) {
+                    if(CPO.blocksIDE) {
+                      // Blocks editor case
                       var snapColor = hueToSnapColor(color);
-                      console.log(positions[0].from);
-                      console.log(positions[0].to);
                       CPO.blocksIDE.flashSpriteScriptAt(
                         locsArray[0].dict['start-char'] + 1,
                         undefined,
                         snapColor);
-                      console.log({
-                        message: 'flash sprite position',
-                        index: locsArray[0].dict['start-char'] + 1,
-                        snapColor
-                      })
-                    }
-                  } else {
-                    if (positions[0] !== undefined)
+                    } else {
+                      // Non-Blocks editor
                       positions[0].hint();
+                    }
                   }
                   emphasize(color);
                 });

--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -41,6 +41,14 @@
       return converter([74, a, b]);
     }
 
+    // Snap wants colors specified as "r,g,b(,a)" where each is [0-255]
+    var snapConverter = $.colorspaces.converter('CIELAB', 'sRGB')
+    function hueToSnapColor(hue) {
+      var a = 40*Math.cos(hue);
+      var b = 40*Math.sin(hue)
+      return snapConverter([74, a, b]).map(x => Math.floor(x * 255)).join(",")
+    }
+
     var goldenAngle = 2.39996322972865332;
     var lastHue = 0;
 
@@ -1079,9 +1087,12 @@
                   // Blocks editor case
                   if(CPO.blocksIDE) {
                     if(positions.length > 0) {
+                      var snapColor = hueToSnapColor(color);
                       CPO.blocksIDE.flashSpriteScripts(
                         positions[0].from.line + 1, // CPO is 0-based, Snap is 1-based
-                        positions[0].to.line + 1);
+                        positions[0].to.line + 1,
+                        undefined,
+                        snapColor);
                     }
                   } else {
                     if (positions[0] !== undefined)

--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -1042,12 +1042,6 @@
               var color = hue;
               var anchor = $("<a>").append(helpContents).addClass("highlight");
               var locsArray = ffi.toArray(locs);
-              console.log({
-                message: "Getting source location in `highlight`",
-                srcloc,
-                locsArray,
-                documents
-              })
               var positions = locsArray
                   .map(function(loc){
                     return Position.fromPyretSrcloc(runtime, srcloc, loc, documents);

--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -1070,19 +1070,23 @@
                 });
               });
               anchor.on("mouseenter", function () {
-                // FIXME: experimental first test of Blocks highlighting
-                if(positions.length > 0 && CPO.blocksIDE) {
-                  CPO.blocksIDE.flashSpriteScripts(
-                    positions[0].from.line + 1, // CPO is 0-based, Snap is 1-based
-                    positions[0].to.line + 1);
-                }
                 logger.log("highlight_anchor_mouseenter",
                   { error_id: context, anchor_id: id });
                 window.requestAnimationFrame(function() {
                   logger.log("highlight_anchor_hover",
                     { error_id: context, anchor_id: id });
-                  if (positions[0] !== undefined)
-                    positions[0].hint();
+
+                  // Blocks editor case
+                  if(CPO.blocksIDE) {
+                    if(positions.length > 0) {
+                      CPO.blocksIDE.flashSpriteScripts(
+                        positions[0].from.line + 1, // CPO is 0-based, Snap is 1-based
+                        positions[0].to.line + 1);
+                    }
+                  } else {
+                    if (positions[0] !== undefined)
+                      positions[0].hint();
+                  }
                   emphasize(color);
                 });
               });
@@ -1090,7 +1094,14 @@
                 logger.log("highlight_anchor_mouseleave",
                   { error_id: context, anchor_id: id });
                 window.requestAnimationFrame(function() {
-                  unhintLoc();
+                  // Blocks editor case
+                  if(CPO.blocksIDE) {
+                    if(positions.length > 0) {
+                      CPO.blocksIDE.unflashSpriteScripts();
+                    }
+                  } else {
+                    unhintLoc();
+                  }
                   demphasize(color);
                 });
               });

--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -1070,6 +1070,12 @@
                 });
               });
               anchor.on("mouseenter", function () {
+                // FIXME: experimental first test of Blocks highlighting
+                if(positions.length > 0 && CPO.blocksIDE) {
+                  CPO.blocksIDE.flashSpriteScripts(
+                    positions[0].from.line + 1, // CPO is 0-based, Snap is 1-based
+                    positions[0].to.line + 1);
+                }
                 logger.log("highlight_anchor_mouseenter",
                   { error_id: context, anchor_id: id });
                 window.requestAnimationFrame(function() {

--- a/src/web/js/output-ui.js
+++ b/src/web/js/output-ui.js
@@ -1042,6 +1042,12 @@
               var color = hue;
               var anchor = $("<a>").append(helpContents).addClass("highlight");
               var locsArray = ffi.toArray(locs);
+              console.log({
+                message: "Getting source location in `highlight`",
+                srcloc,
+                locsArray,
+                documents
+              })
               var positions = locsArray
                   .map(function(loc){
                     return Position.fromPyretSrcloc(runtime, srcloc, loc, documents);
@@ -1088,11 +1094,17 @@
                   if(CPO.blocksIDE) {
                     if(positions.length > 0) {
                       var snapColor = hueToSnapColor(color);
-                      CPO.blocksIDE.flashSpriteScripts(
-                        positions[0].from.line + 1, // CPO is 0-based, Snap is 1-based
-                        positions[0].to.line + 1,
+                      console.log(positions[0].from);
+                      console.log(positions[0].to);
+                      CPO.blocksIDE.flashSpriteScriptAt(
+                        locsArray[0].dict['start-char'] + 1,
                         undefined,
                         snapColor);
+                      console.log({
+                        message: 'flash sprite position',
+                        index: locsArray[0].dict['start-char'] + 1,
+                        snapColor
+                      })
                     }
                   } else {
                     if (positions[0] !== undefined)


### PR DESCRIPTION
This PR adds basic error highlighting to the Blocks UI.

- When an error is shown in the REPL side, hovering the highlighted bits trigger a matching highlight on the top-level block where the error occured: ![image](https://github.com/brownplt/code.pyret.org/assets/8495/d8d0be02-d70a-4b4c-8ce1-caccb89213fd)

- It also upgrades Snap to the latest version, which fixes a bug we encountered with Snap not re-running our code generation after some UI interactions.