### PR TITLE
Enter submits modals.

### DIFF
--- a/src/web/js/modal-prompt.js
+++ b/src/web/js/modal-prompt.js
@@ -111,6 +111,12 @@ define("cpo/modal-prompt", ["q"], function(Q) {
       this.submitButton.show();
     }
     this.closeButton.click(this.onClose.bind(this));
+    this.modal.keypress(function(e) {
+      if(e.which == 13) {
+        this.submitButton.click();
+        return false;
+      }
+    }.bind(this));
     this.submitButton.click(this.onSubmit.bind(this));
     var docClick = (function(e) {
       // If the prompt is active and the background is clicked,


### PR DESCRIPTION
Resolves #277.

We already auto-focus the submit button for modals with no inputs, so enter already works there. With this change, if the modal has text inputs, hitting enter while focused on one of these text inputs will also immediately try to submit.

If we ever add modals that have inputs where enter should do something else (like a multi-line textarea comment box), we'll need to ensure that input captures and does not bubble the enter event, so that it doesn't trigger this.