### PR TITLE
Improve styling of Rename modal and modal cancel buttons.

### DIFF
--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -2379,7 +2379,7 @@ table.pyret-row {
 .modal .close{
   border: 1px solid #ccc;
   background: white;
-  color: #999;
+  color: var(--run-bg);
   margin-right: 16px;
 }
 

--- a/src/web/js/beforeBlocks.js
+++ b/src/web/js/beforeBlocks.js
@@ -795,6 +795,7 @@ $(function() {
         title: "Rename this file",
         style: "text",
         narrow: true,
+        submitText: "Rename",
         options: [
           {
             message: "The new name for the file:",

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -793,6 +793,7 @@ $(function() {
         title: "Rename this file",
         style: "text",
         narrow: true,
+        submitText: "Rename",
         options: [
           {
             message: "The new name for the file:",


### PR DESCRIPTION
Resolves #350.

| Before | After |
| ---- | ---- |
| <img width="439" alt="image" src="https://github.com/brownplt/code.pyret.org/assets/8495/de03bffd-7942-4af1-b3a0-2702ec09f392"> | <img width="438" alt="image" src="https://github.com/brownplt/code.pyret.org/assets/8495/fdd1d627-92c0-4a72-9f12-8c326e410ba8"> |

- Rename modal's submit button now says Rename
- All modal cancel buttons have blue, rather than gray, text, to show they are clickable and to match Google styles.

In the initial issue, @shriram asked:

> I also feel like the very light grey of Cancel makes it looks like it's not enabled. Is the grey instead of red for cancel a consistent style?

I agree that the light gray only makes it look not enabled. This PR makes the text blue to match the styles commonly used in the Google/Chromebook apps that students will be familiar with. e.g. here is a sample from Google Docs:

<img width="319" alt="image" src="https://github.com/brownplt/code.pyret.org/assets/8495/47026b18-a56a-48ed-9e7b-479caf22cce0">

In general, I'd recommend we not use red for non-destructive secondary actions like "close", as it has a connotation of something dangerous, whereas in this case close should clearly be taken as the neutral action with no side-effects. CPO no longer uses red for any secondary actions that I can find from clicking around.
