### PR TITLE
Remove zero-width space characters when pasting text into CPO.

### DIFF
--- a/src/web/js/text-handlers.js
+++ b/src/web/js/text-handlers.js
@@ -13,7 +13,8 @@
                             [/\u201C/g, "\""],
                             [/\u2019/g, "\'"],
                             [/\u2018/g, "\'"],
-                            [/\u2026/g, "..."]], changeObj, cm);
+                            [/\u2026/g, "..."],
+                            [/\u200b/g, ""]], changeObj, cm);
       var endash = change([[/\u2013/g, "-"]], changeObj, cm);
       if (curlyq && endash) {
         autoCorrectUndo("Curly Quotes and Invalid Dash (en dash) converted", originalText, changeObj.from, cm);


### PR DESCRIPTION
Resolves #508.

## Testing
I constructed a sample paste payload that included a valid function definition plus some ZWS characters. Here is what I got:

Before:
![image](https://github.com/brownplt/code.pyret.org/assets/8495/e00ccbb5-0f94-463c-9be7-ee690cc22d15)

After:
![image](https://github.com/brownplt/code.pyret.org/assets/8495/7de813ef-a0a8-4922-8a60-89a93135e5fe)

## Discussion
I think this change is net positive right away, but there's a larger possible discussion here:

- There are a lot of formatting-only characters in Unicode, and eventually we'll run into others we also want to strip out.
- _But_, those characters have meaning, or are even required, when used in human-readable text, so a smarter version of this would ideally leave them in comments and string literals that appear in the source. (Of course, that would require being able to parse the program text, which our parser currently can't do when these characters are included, so ...)