### PR TITLE
Blocks language supports benchmark program

### DIFF
--- a/src/web/js/transpile.xml
+++ b/src/web/js/transpile.xml
@@ -80,7 +80,23 @@ else:
                     <translations />
                     <inputs>
                         <input type="%upvar">name</input>
-                        <input type="%n">val</input>
+                        <input type="%s">val</input>
+                    </inputs>
+                    <script>
+                        <block s="doReport">
+                            <l />
+                        </block>
+                    </script>
+                </block-definition>
+
+                <block-definition category="Maps" s="%'name' [ %'arg' ]"
+                    type="reporter">
+                    <header />
+                    <code>&lt;#1&gt;[&lt;#2&gt;]</code>
+                    <translations />
+                    <inputs>
+                        <input type="%var">map</input>
+                        <input type="%s">key</input>
                     </inputs>
                     <script>
                         <block s="doReport">

--- a/src/web/js/transpile.xml
+++ b/src/web/js/transpile.xml
@@ -207,7 +207,7 @@ else:
                     <translations/>
                     <inputs>
                         <input type="%upvar"></input>
-                        <input type="%upvar"></input>
+                        <input type="%mult%upvar"></input>
                         <input type="%s"></input>
                     </inputs>
                     <script>
@@ -221,8 +221,8 @@ else:
                     <code>&lt;#1&gt;(&lt;#2&gt;)</code>
                     <translations/>
                     <inputs>
-                        <input type="%upvar"></input>
-                        <input type="%s"></input>
+                        <input type="%txt"></input>
+                        <input type="%mult%s"></input>
                     </inputs>
                     <script>
                         <block s="doReport">

--- a/src/web/js/transpile.xml
+++ b/src/web/js/transpile.xml
@@ -73,6 +73,21 @@ else:
                         <input type="%txt"/>
                     </inputs>
                 </block-definition>
+
+                <block-definition category="Variables" s="%'a' = %'b'" type="reporter">
+                    <header />
+                    <code>&lt;#1&gt; = &lt;#2&gt;</code>
+                    <translations />
+                    <inputs>
+                        <input type="%upvar">name</input>
+                        <input type="%n">val</input>
+                    </inputs>
+                    <script>
+                        <block s="doReport">
+                            <l />
+                        </block>
+                    </script>
+                </block-definition>
                 <block-definition category="Numbers" s="%'a' + %'b'" type="reporter">
                     <header/>
                     <code>(&lt;#1&gt; + &lt;#2&gt;)</code>
@@ -101,6 +116,7 @@ else:
                         </block>
                     </script>
                 </block-definition>
+                
                 <block-definition category="Numbers" s="%'a' / %'b'" type="reporter">
                     <header/>
                     <code>(&lt;#1&gt; / &lt;#2&gt;)</code>

--- a/src/web/js/transpile.xml
+++ b/src/web/js/transpile.xml
@@ -781,7 +781,7 @@ else:
                     <inputs>
                         <input type="%s"/>
                         <input type="%s"/>
-                        <input type="%mult%txt"/>
+                        <input type="%mult%upvar"/>
                     </inputs>
                     <script>
                         <block s="doReport">


### PR DESCRIPTION
This PR contains changes to the Snap definitions of the Pyret language to enable us to construct the demo program we want to be able to run [the benchmark program](https://code.pyret.org/editor#share=1hmVFpA2zWBWaKulm6LwHHzKrDhH15jvP).

In [previous testing](https://github.com/brownplt/code.pyret.org/issues/501#issuecomment-1970138201), we found a few missing items:

- [x] Introduce a new variable and assign it to a value: `var = val`
- [x] Lookup for `Row`, `StringDict` and other map-like things: `map[key]`
    ![image](https://github.com/brownplt/code.pyret.org/assets/8495/9ca8817f-8094-4bb0-b4a0-3341cd5385f6)

- [x] image-scatter-plot (turns out this already worked and Adam just misunderstood)
- [x] load-table can define multiple column names as variables
    <img width="380" alt="image" src="https://github.com/brownplt/code.pyret.org/assets/8495/e3961443-e0da-426b-97d5-9443197b3007">

- [x] allow multiple arguments in function definitions and applications
    <img width="298" alt="image" src="https://github.com/brownplt/code.pyret.org/assets/8495/232273d2-21dd-4f83-b887-d9aae0b4d5c0">
