### PR TITLE
Blocks definitions improvements

### DIFF
--- a/src/web/js/transpile.xml
+++ b/src/web/js/transpile.xml
@@ -953,7 +953,7 @@ else:
                 </block-definition>
                 <block-definition category="Tables" s="image-scatter-plot %'table' %'x-values' %'y-values' %'f'" type="reporter">
                     <header/>
-                    <code>scatter-plot(&lt;#1&gt;,&lt;#2&gt;,&lt;#3&gt;,&lt;#4&gt;)</code>
+                    <code>image-scatter-plot(&lt;#1&gt;,&lt;#2&gt;,&lt;#3&gt;,&lt;#4&gt;)</code>
                     <translations/>
                     <inputs>
                         <input type="%s"/>


### PR DESCRIPTION
Now that the [core Blocks demo](https://pyret-horizon.herokuapp.com/editor#share=1gTlfUFhsGtJlHA4-sCLRS36kx7I9oi55) is mostly working on Horizon, I expect a long list of tiny nitpicks to the block definitions as we try things out. Creating this as a tracking issue to get them cleaned up.

- [x] Fix code generated by `image-scatter-plot` block to actually call that function instead of `scatter-plot`.

Please send requests!