### PR TITLE
Choose Context modal doesn't show bad non-context strings

### DIFF
--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -447,6 +447,8 @@ $(function() {
     $("#download").append(downloadElt);
   });
 
+  const CONTEXT_PREFIX = "use context ";
+
   function showModal(currentContext) {
     function drawElement(input) {
       const element = $("<div>");
@@ -485,11 +487,18 @@ $(function() {
       });
     namespaceResult.show((result) => {
       if(!result) { return; }
-      if(result.match(/^use context*/)) { result = result.slice("use context ".length); }
-      CPO.editor.setContextLine("use context " + result + "\n");
+      if(result.startsWith(CONTEXT_PREFIX)) { result = result.slice(CONTEXT_PREFIX.length); }
+      CPO.editor.setContextLine(CONTEXT_PREFIX + result + "\n");
     });
   }
-  $("#choose-context").on("click", function() { showModal(CPO.editor.cm.getLine(0).slice("use context ".length)); });
+  $("#choose-context").on("click", function() {
+    let currentContext = "";
+    let firstLine = CPO.editor.cm.getLine(0);
+    if(firstLine.startsWith(CONTEXT_PREFIX)) {
+      currentContext = firstLine.slice(CONTEXT_PREFIX.length);
+    }
+    showModal(currentContext);
+  });
 
   var TRUNCATE_LENGTH = 20;
 


### PR DESCRIPTION
Fixes #399

Previously, if your first line wasn't a `use context` declaration, the Choose Context modal would just grab an arbitrary substring of your first line, resulting in gibberish.

This change first checks if the first line is actually a `use context`. If so, it shows the current context. If not, it shows the current context as blank and lets you enter a new one.