### PR TITLE
Disable checking file name and erroring for shared gdrive files.

### DIFF
--- a/src/web/js/gdrive-locators.js
+++ b/src/web/js/gdrive-locators.js
@@ -164,12 +164,6 @@ define("cpo/gdrive-locators", [], function() {
     // Shared GDrive locators require a refresh to be re-fetched
     var sharedLocatorCache = {};
     function makeSharedGDriveLocator(filename, id) {
-      function checkFileResponse(file, filename, restarter) {
-        var actualName = file.getName();
-        if(actualName !== filename) {
-          restarter.error(runtime.ffi.makeMessageException("Expected file with id " + id + " to have name " + filename + ", but its name was " + actualName));
-        }
-      }
       function contentRequestFailure(failure) {
         return "Could not load file with name " + filename;
       }
@@ -192,8 +186,6 @@ define("cpo/gdrive-locators", [], function() {
           restarter.error(runtime.ffi.makeMessageException(fileRequestFailure(failure, filename)));
         });
         var fileP = filesP.then(function(file) {
-          checkFileResponse(file, filename, restarter);
-          // checkFileResponse throws if there's an error
           return file;
         });
         var contentsP = Q.all([fileP, fileP.then(function(file) {


### PR DESCRIPTION
This is a minimal version of fixing https://github.com/brownplt/code.pyret.org/issues/517.

Whether this is a good idea or not is outside of my ability to judge.

Even if this is a good idea at a high level, there are two other things we might want to do:
- Make the filename itself optional, so it's just not needed.
- Update the source code of the current file to reflect the new name. This would prevent confusion but also introduces a surprising information leak if the file is renamed without the new name being safe to share.