### PR TITLE
An initial attempt to fix #534

### DIFF
--- a/src/web/js/trove/world.js
+++ b/src/web/js/trove/world.js
@@ -533,13 +533,13 @@
     DefaultDrawingOutput.prototype.toRawHandler = function(toplevelNode) {
       var that = this;
       var worldFunction = function(world, success) {
-        var textNode = jQuery("<pre>");
+        var hostNode = document.createElement("div");
         return runtime.safeCall(function() {
-          return runtime.toReprJS(world, runtime.ReprMethods._torepr);
-        }, function(str) {
-          textNode.text(str);
+          return runtime.toReprJS(world, runtime.ReprMethods['$cpo']);
+        }, function(jNode) {
+          $(hostNode).append(jNode);
           success([toplevelNode,
-                   rawJsworld.node_to_tree(textNode[0])]);
+                   rawJsworld.node_to_tree(hostNode)]);
         }, "default-drawing:toRepr");
       };
       var cssFunction = function(w, success) { success([]); }


### PR DESCRIPTION
The request is to render the `display`ed version of a Pyret value instead of its `to-repr` rendering.  Note that this interacts oddly with mouse handlers and key handlers, since displayed values are interactive but so is a reactor, and keyboard focus can get screwed up.  There's also no limit to the size of the window; we might want to impose a maximum size and a overflow: scroll on these...but I don't understand the cssFunction well enough to know how to apply that.

Potentially fixes #534 