### PR TITLE
Update version of pyret-lang.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14616,7 +14616,7 @@
     },
     "node_modules/pyret-lang": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/brownplt/pyret-lang.git#5e19a87aca5b670fa9348f344da8a0388ee3e9a5",
+      "resolved": "git+ssh://git@github.com/brownplt/pyret-lang.git#eeef8a7a7235f688558bc3d0eeb3fe0c95c8f5fd",
       "bundleDependencies": [
         "browserify"
       ],


### PR DESCRIPTION
CPO now depends on a newer version of `pyret-lang` than is in the lock file. This fixes that and should make a fresh checkout build correctly.

Fixes #545 