### PR TITLE
An implementation of dot charts

### DIFF
--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1918,6 +1918,21 @@ fun bar-chart-from-list(labels :: P.LoS, values :: P.LoN) -> DataSeries block:
   data-series.make-axis(max-positive-height, max-negative-height)
 end
 
+fun num-dot-chart-from-list(labels :: P.LoN, values :: P.LoN) -> DataSeries block:
+  doc: ```
+       Consume labels, a list of numbers, and values, a list of numbers
+       and construct a dot chart
+       ```
+  labels.each(check-num)
+  num-dot-chart-args = map2(lam(x-elt, y-elt): [list: x-elt, y-elt] end, 
+                            labels, values)
+    .sort-by({(x-list, y-list): x-list.get(0) < y-list.get(0)},
+             {(x-list, y-list): x-list.get(0) == y-list.get(0)})
+  dot-chart-from-list(map(lam(x-list): num-to-string(x-list.get(0)) end,
+                          num-dot-chart-args),
+                      map(lam(x-list): x-list.get(1) end, num-dot-chart-args))
+end
+
 fun dot-chart-from-list(labels :: P.LoS, values :: P.LoN) -> DataSeries block:
   doc: ```
        Consume labels, a list of string, and values, a list of numbers
@@ -2651,6 +2666,7 @@ from-list = {
   image-pie-chart: image-pie-chart-from-list,
   bar-chart: bar-chart-from-list,
   dot-chart: dot-chart-from-list,
+  num-dot-chart: num-dot-chart-from-list,
   image-bar-chart: image-bar-chart-from-list,
   grouped-bar-chart: grouped-bar-chart-from-list,
   stacked-bar-chart: stacked-bar-chart-from-list,

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1067,6 +1067,7 @@ default-bar-chart-series = {
   pointer-color: none,
   axisdata: none, 
   horizontal: false, 
+  dot-chart: false,
   default-interval-color: none
 }
 
@@ -1917,6 +1918,42 @@ fun bar-chart-from-list(labels :: P.LoS, values :: P.LoN) -> DataSeries block:
   data-series.make-axis(max-positive-height, max-negative-height)
 end
 
+fun dot-chart-from-list(labels :: P.LoS, values :: P.LoN) -> DataSeries block:
+  doc: ```
+       Consume labels, a list of string, and values, a list of numbers
+       and construct a dot chart
+       ```
+  # Type Checking
+  values.each(check-num)
+  labels.each(check-string)
+
+  # Constants
+  label-length = labels.length()
+  value-length = values.length()
+  rational-values = map(num-to-rational, values)
+
+  # Edge Case Error Checking
+  when value-length == 0:
+    raise("dot-chart: can't have empty data")
+  end
+  when label-length <> value-length:
+    raise('dot-chart: labels and values should have the same length')
+  end
+
+  {max-positive-height; max-negative-height} = prep-axis(rational-values)
+
+  data-series = default-bar-chart-series.{
+    tab: to-table2-n(labels, rational-values),
+    dot-chart: true,
+    axis-top: max-positive-height,
+    axis-bottom: max-negative-height,
+    annotations: values.map({(_): [list: none]}) ^ list-to-table2,
+    intervals: values.map({(_): [list: [raw-array: ]]}) ^ list-to-table2,
+  } ^ bar-chart-series
+
+  data-series.make-axis(max-positive-height, max-negative-height)
+end
+
 fun grouped-bar-chart-from-list(
   labels :: P.LoS,
   value-lists :: P.LoLoN,
@@ -2613,6 +2650,7 @@ from-list = {
   exploding-pie-chart: exploding-pie-chart-from-list,
   image-pie-chart: image-pie-chart-from-list,
   bar-chart: bar-chart-from-list,
+  dot-chart: dot-chart-from-list,
   image-bar-chart: image-bar-chart-from-list,
   grouped-bar-chart: grouped-bar-chart-from-list,
   stacked-bar-chart: stacked-bar-chart-from-list,

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -809,9 +809,10 @@
             const unit_height = rect_height/num_elts;
             const rect_width = Number(rect.getAttribute('width'));
             const rect_fill = rect.getAttribute('fill');
-            const rect_fill_opacity = Number(rect.getAttribute('fill-opacity'));
-            const rect_stroke = rect.getAttribute('stroke');
-            const rect_stroke_width = Number(rect.getAttribute('stroke-width'));
+            // const rect_fill_opacity = Number(rect.getAttribute('fill-opacity'));
+            // const rect_stroke = rect.getAttribute('stroke');
+            // const rect_stroke_width = Number(rect.getAttribute('stroke-width'));
+            rect.setAttribute('stroke-width', 0);
             for (let j = 0; j < num_elts; j++) {
               const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
               circle.classList.add('__img_labels');

--- a/test-util/pyret-programs/charts/dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/dot-chart-test.arr
@@ -7,12 +7,37 @@ include math
 labels = [list: "cats", "dogs", "ants", "elephants"]
 count = [list: 3, 7, 4, 9]
 
-series = from-list.dot-chart(
+zoo-series = from-list.dot-chart(
   labels,
   count)
 
-img = render-chart(series).get-image()
+just-red = [list: C.red]
+rainbow-colors = [list: C.red, C.orange, C.yellow, C.green, C.blue, C.indigo, C.violet]
+manual-colors =
+  [list:
+    C.color(51, 72, 252, 0.57), C.color(195, 180, 104, 0.87),
+    C.color(115, 23, 159, 0.24), C.color(144, 12, 138, 0.13),
+    C.color(31, 132, 224, 0.83), C.color(166, 16, 72, 0.59),
+    C.color(58, 193, 241, 0.98)]
+fewer-colors = [list: C.red, C.green, C.blue, C.orange, C.purple]
+more-colors = [list: C.red, C.green, C.blue, C.orange, C.purple, C.yellow, C.indigo, C.violet]
+
+fun render-image(series):
+  render-chart(series).get-image()
+end
+
+zoo = render-image(zoo-series)
+zoo-red = render-image(zoo-series.colors(just-red))
+zoo-rainbow = render-image(zoo-series.colors(rainbow-colors))
+zoo-manual = render-image(zoo-series.colors(manual-colors))
+zoo-fewer = render-image(zoo-series.colors(fewer-colors))
+zoo-more = render-image(zoo-series.colors(more-colors))
 
 check:
-  img satisfies is-image
+  zoo satisfies is-image
+  zoo-red satisfies is-image
+  zoo-rainbow satisfies is-image
+  zoo-manual satisfies is-image
+  zoo-fewer satisfies is-image
+  zoo-more satisfies is-image
 end

--- a/test-util/pyret-programs/charts/dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/dot-chart-test.arr
@@ -6,10 +6,11 @@ include math
 
 labels = [list: "cats", "dogs", "ants", "elephants"]
 count = [list: 3, 7, 4, 9]
+nlabels = [list: 2, 4, 3, 1]
 
-zoo-series = from-list.dot-chart(
-  labels,
-  count)
+zoo-series = from-list.dot-chart(labels, count)
+
+n-zoo-series = from-list.num-dot-chart(nlabels, count)
 
 just-red = [list: C.red]
 rainbow-colors = [list: C.red, C.orange, C.yellow, C.green, C.blue, C.indigo, C.violet]
@@ -33,6 +34,13 @@ zoo-manual = render-image(zoo-series.colors(manual-colors))
 zoo-fewer = render-image(zoo-series.colors(fewer-colors))
 zoo-more = render-image(zoo-series.colors(more-colors))
 
+n-zoo = render-image(n-zoo-series)
+n-zoo-red = render-image(n-zoo-series.colors(just-red))
+n-zoo-rainbow = render-image(n-zoo-series.colors(rainbow-colors))
+n-zoo-manual = render-image(n-zoo-series.colors(manual-colors))
+n-zoo-fewer = render-image(n-zoo-series.colors(fewer-colors))
+n-zoo-more = render-image(n-zoo-series.colors(more-colors))
+
 check:
   zoo satisfies is-image
   zoo-red satisfies is-image
@@ -40,4 +48,11 @@ check:
   zoo-manual satisfies is-image
   zoo-fewer satisfies is-image
   zoo-more satisfies is-image
+
+  n-zoo satisfies is-image
+  n-zoo-red satisfies is-image
+  n-zoo-rainbow satisfies is-image
+  n-zoo-manual satisfies is-image
+  n-zoo-fewer satisfies is-image
+  n-zoo-more satisfies is-image
 end

--- a/test-util/pyret-programs/charts/dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/dot-chart-test.arr
@@ -55,4 +55,9 @@ check:
   n-zoo-manual satisfies is-image
   n-zoo-fewer satisfies is-image
   n-zoo-more satisfies is-image
+
+  color-at-position(zoo-rainbow, 208, 340) is C.red
+  color-at-position(zoo-rainbow, 322, 340) is C.orange
+  color-at-position(zoo-rainbow, 439, 340) is C.yellow
+  color-at-position(zoo-rainbow, 558, 340) is C.green
 end

--- a/test-util/pyret-programs/charts/dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/dot-chart-test.arr
@@ -1,0 +1,18 @@
+include chart
+include image
+import color as C
+# include image-structs
+include math
+
+labels = [list: "cats", "dogs", "ants", "elephants"]
+count = [list: 3, 7, 4, 9]
+
+series = from-list.dot-chart(
+  labels,
+  count)
+
+img = render-chart(series).get-image()
+
+check:
+  img satisfies is-image
+end

--- a/test-util/pyret-programs/charts/image-bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/image-bar-chart-test.arr
@@ -1,6 +1,7 @@
 include chart
 include image
-include image-structs
+import color as C
+# include image-structs  # color tan clashes with starter2024's trig tan
 include math
 
 fun f(r): star(50, "solid", "red") end
@@ -19,5 +20,5 @@ img = render-chart(series)
 
 check:
   img satisfies is-image
-  color-at-position(img, 504, 258) is red
+  color-at-position(img, 504, 258) is C.red
 end


### PR DESCRIPTION
Issue #469 

Usage: `from-list.dot-chart(labels, counts)`, where `labels` and `counts` are lists -- the signature is exactly as for `bar-chart`.  An example of a dot chart it produces:

![Image 10-9-24 at 5 32 PM](https://github.com/user-attachments/assets/dba9149d-aa73-4581-b6b1-c738c2c49054)
