### PR TITLE
Num dot charts

### DIFF
--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1919,102 +1919,22 @@ fun bar-chart-from-list(labels :: P.LoS, values :: P.LoN) -> DataSeries block:
   data-series.make-axis(max-positive-height, max-negative-height)
 end
 
-fun num-dot-chart-no-bin(x-values :: P.LoN, y-values :: P.LoN,
-      min-x-value :: Number, max-x-value :: Number):
-  num-dot-chart-args = map2(lam(x-value, y-value): [list: x-value, y-value] end,
-                            x-values, y-values)
-    .append(range(min-x-value, max-x-value)
-      .filter(lam(x-value): not(member(x-values, x-value)) end)
-      .map(lam(x-value): [list: x-value, 0] end))
-    .sort-by({(x1y1, x2y2): x1y1.get(0) < x2y2.get(0)},
-             {(x1y1, x2y2): x1y1.get(0) == x2y2.get(0)})
-  dot-chart-from-list(map(lam(x1y1): num-to-string(x1y1.get(0)) end,
-                          num-dot-chart-args),
-                      map(lam(x1y1): x1y1.get(1) end, num-dot-chart-args))
-end
-
-fun num-dot-chart-bin(labels :: P.LoN, values :: P.LoN) block:
-  actual-num-of-xs = fold(lam(num1, num2): num1 + num2 end, 0, values)
-  num-dot-chart-args-ra = raw-array-build(lam(_): 0 end, actual-num-of-xs)
-  var num-dot-chart-i = 0
-  for each2(x-value from labels, y-value from values):
-    for each(y-value-i from range(0, y-value)) block:
-       raw-array-set(num-dot-chart-args-ra, num-dot-chart-i, x-value)
-       num-dot-chart-i := num-dot-chart-i + 1
-    end
-  end
-  scatter-plot-xs = raw-array-to-list(num-dot-chart-args-ra)
-  scatter-plot-ys = map(lam(_): 0 end, scatter-plot-xs)
-  default-scatter-plot-series.{
-    ps: map4({(x, y, z, img): [raw-array: x, y, z, img]},
-      scatter-plot-xs, scatter-plot-ys,
-      scatter-plot-xs.map({(_): ''}), scatter-plot-xs.map({(_): false})),
-    dot-chart: true
-  } ^ scatter-plot-series
-end
-
-fun old-num-dot-chart-bin(labels :: P.LoN, values :: P.LoN,
-      min-x-value :: Number, max-x-value :: Number) block:
-  labels-length = labels.length()
-  median-index = labels-length / 2
-  sorted-labels = labels.sort()
-  sorted-labels-split = sorted-labels.split-at(num-floor(median-index))
-  sorted-labels-1st-half = sorted-labels.split-at(num-floor(median-index)).prefix
-  sorted-labels-2nd-half = sorted-labels.split-at(num-ceiling(median-index)).suffix
-  sorted-labels-iqr = ST.median(sorted-labels-2nd-half) -
-                        ST.median(sorted-labels-1st-half)
-  # bin width based on Freedman-Diaconis rule
-  dot-chart-bin-width-1 = ((2 * sorted-labels-iqr) /
-                            num-expt(labels-length, 1/3))
-  # if bin width > 1, make it an even int
-  dot-chart-bin-width = if dot-chart-bin-width-1 > 1:
-      num-round-even(dot-chart-bin-width-1) else: dot-chart-bin-width-1 end
-  left-most-x-1 = min-x-value - (dot-chart-bin-width / 2)
-  # if all x's are positive, don't make first interval start negative
-  left-most-x-2 = if all(num-is-positive, labels) and num-is-negative(left-most-x-1):
-                      min-x-value else: left-most-x-1 end
-  # if bin width > 0.5, keep x's integral
-  left-most-x = if dot-chart-bin-width > 0.5: num-floor(left-most-x-2) else:
-                      left-most-x-2 end
-  num-bins = num-ceiling((max-x-value - left-most-x) / dot-chart-bin-width)
-  num-dot-chart-args = for map(range-iter from range(0, num-bins)):
-    [raw-array: "[" +
-      num-to-string(left-most-x + (range-iter * dot-chart-bin-width)) +
-      "," + num-to-string(left-most-x + ((range-iter + 1) * dot-chart-bin-width)) + ")",
-      0]
-    end
-  for each2(x-value from labels, y-value from values):
-    x-index = num-min(num-floor((x-value - left-most-x) / dot-chart-bin-width),
-                      num-bins - 1)
-    this-ra = num-dot-chart-args.get(x-index)
-    raw-array-set(this-ra, 1, raw-array-get(this-ra, 1) + y-value)
-  end
-  dot-chart-from-list(map(lam(x1y1): raw-array-get(x1y1, 0) end, num-dot-chart-args),
-                      map(lam(x1y1): raw-array-get(x1y1, 1) end, num-dot-chart-args))
-end
-
-fun num-dot-chart-from-list(labels :: P.LoN, values :: P.LoN) -> DataSeries block:
+fun num-dot-chart-from-list(x-values :: P.LoN) -> DataSeries block:
   doc: ```
-       Consume labels, a list of numbers, and values, a list of numbers
+       Consume a (possibly repeating, unordered) list of numbers
        and construct a dot chart
        ```
-  labels.each(check-num)
-  labels-length = labels.length()
-  when labels-length == 0:
+  x-values.each(check-num)
+  when x-values.length() == 0:
     raise("num-dot-chart: can't have empty data")
   end
-  when labels-length <> values.length():
-    raise("num-dot-chart: labels and values should have the same length")
-  end
-  any-x-value = labels.get(0)
-  min-x-value = fold(num-min, any-x-value, labels)
-  max-x-value = fold(num-max, any-x-value, labels)
-  # create a binned chart if x range is large or if some x's are noninteger
-  if (not(all(num-is-integer, labels)) or ((max-x-value - min-x-value) > 15)): 
-    num-dot-chart-bin(labels, values)
-  else:
-    num-dot-chart-no-bin(labels, values, min-x-value, max-x-value)
-  end
+  scatter-plot-ys = x-values.map(lam(_): 0 end)
+  default-scatter-plot-series.{
+    ps: map4({(x, y, z, img): [raw-array: x, y, z, img]},
+      x-values, scatter-plot-ys,
+      x-values.map({(_): ''}), x-values.map({(_): false})),
+    dot-chart: true
+  } ^ scatter-plot-series
 end
 
 fun dot-chart-from-list(labels :: P.LoS, values :: P.LoN) -> DataSeries block:

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1058,6 +1058,7 @@ type BarChartSeries = {
   annotations :: RawArray<RawArray<Option<String>>>,
   intervals :: RawArray<RawArray<RawArray<Number>>>,
   default-interval-color :: Option<I.Color>
+  dot-chart :: Boolean,
 }
 
 default-bar-chart-series = {
@@ -1067,8 +1068,8 @@ default-bar-chart-series = {
   pointer-color: none,
   axisdata: none, 
   horizontal: false, 
-  dot-chart: false,
   default-interval-color: none
+  dot-chart: false,
 }
 
 type MultiBarChartSeries = { 
@@ -1163,6 +1164,7 @@ type ScatterPlotSeries = {
   pointshapeSides :: NumInteger, 
   pointshapeDent :: Number, 
   pointshapeRotation :: Number,
+  dot-chart :: Boolean,
 }
 
 default-scatter-plot-series = {
@@ -1193,9 +1195,6 @@ type IntervalChartSeries = {
   style :: String,
   horizontal :: Boolean,
   default-interval-color :: Option<I.Color>,
-  #
-  bothys :: List<Posn>,
-  ps :: List<Posn>,
   legend :: String,
   trendlineType :: Option<String>,
   trendlineColor :: Option<I.Color>,
@@ -1209,6 +1208,9 @@ type IntervalChartSeries = {
   pointshapeSides :: NumInteger,
   pointshapeDent :: Number,
   pointshapeRotation :: Number,
+  bothys :: List<Posn>,
+  ps :: List<Posn>,
+  dot-chart :: Boolean,
 }
 
 default-interval-chart-series = {
@@ -1232,6 +1234,7 @@ default-interval-chart-series = {
   pointshapeSides: 5,
   pointshapeDent: 0.5,
   pointshapeRotation: 0,
+  dot-chart: false,
 }
 
 type FunctionPlotSeries = {

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1178,6 +1178,7 @@ default-scatter-plot-series = {
   trendlineWidth: 3, 
   trendlineOpacity: 0.3,
   trendlineDegree: 3,  
+  dot-chart: false
 }
 
 type IntervalChartSeries = {
@@ -1932,22 +1933,24 @@ fun num-dot-chart-no-bin(x-values :: P.LoN, y-values :: P.LoN,
                       map(lam(x1y1): x1y1.get(1) end, num-dot-chart-args))
 end
 
-fun num-dot-chart-bin(labels :: P.LoN, values :: P.LoN,
-      min-x-value :: Number, max-x-value :: Number) block:
+fun num-dot-chart-bin(labels :: P.LoN, values :: P.LoN) block:
   actual-num-of-xs = fold(lam(num1, num2): num1 + num2 end, 0, values)
-  num-dot-chart-args-ra = raw-array-build(lam(_): [raw-array: 0, 0] end, actual-num-of-xs)
+  num-dot-chart-args-ra = raw-array-build(lam(_): 0 end, actual-num-of-xs)
   var num-dot-chart-i = 0
   for each2(x-value from labels, y-value from values):
-    for each(y-value-i from range(1, y-value + 1)) block:
-       raw-array-set(num-dot-chart-args-ra, num-dot-chart-i,
-         [raw-array: x-value, y-value-i])
+    for each(y-value-i from range(0, y-value)) block:
+       raw-array-set(num-dot-chart-args-ra, num-dot-chart-i, x-value)
        num-dot-chart-i := num-dot-chart-i + 1
     end
   end
-  num-dot-chart-args = raw-array-to-list(num-dot-chart-args-ra)
-  # spy: num-dot-chart-args end
-  scatter-plot-from-list(map(lam(x1y1): raw-array-get(x1y1, 0) end, num-dot-chart-args),
-    map(lam(x1y1): raw-array-get(x1y1, 1) end, num-dot-chart-args))
+  scatter-plot-xs = raw-array-to-list(num-dot-chart-args-ra)
+  scatter-plot-ys = map(lam(_): 0 end, scatter-plot-xs)
+  default-scatter-plot-series.{
+    ps: map4({(x, y, z, img): [raw-array: x, y, z, img]},
+      scatter-plot-xs, scatter-plot-ys,
+      scatter-plot-xs.map({(_): ''}), scatter-plot-xs.map({(_): false})),
+    dot-chart: true
+  } ^ scatter-plot-series
 end
 
 fun old-num-dot-chart-bin(labels :: P.LoN, values :: P.LoN,
@@ -2008,7 +2011,7 @@ fun num-dot-chart-from-list(labels :: P.LoN, values :: P.LoN) -> DataSeries bloc
   max-x-value = fold(num-max, any-x-value, labels)
   # create a binned chart if x range is large or if some x's are noninteger
   if (not(all(num-is-integer, labels)) or ((max-x-value - min-x-value) > 15)): 
-    num-dot-chart-bin(labels, values, min-x-value, max-x-value)
+    num-dot-chart-bin(labels, values)
   else:
     num-dot-chart-no-bin(labels, values, min-x-value, max-x-value)
   end

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1057,7 +1057,7 @@ type BarChartSeries = {
   horizontal :: Boolean,
   annotations :: RawArray<RawArray<Option<String>>>,
   intervals :: RawArray<RawArray<RawArray<Number>>>,
-  default-interval-color :: Option<I.Color>
+  default-interval-color :: Option<I.Color>,
   dot-chart :: Boolean,
 }
 
@@ -1068,7 +1068,7 @@ default-bar-chart-series = {
   pointer-color: none,
   axisdata: none, 
   horizontal: false, 
-  default-interval-color: none
+  default-interval-color: none,
   dot-chart: false,
 }
 

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1934,6 +1934,24 @@ end
 
 fun num-dot-chart-bin(labels :: P.LoN, values :: P.LoN,
       min-x-value :: Number, max-x-value :: Number) block:
+  actual-num-of-xs = fold(lam(num1, num2): num1 + num2 end, 0, values)
+  num-dot-chart-args-ra = raw-array-build(lam(_): [raw-array: 0, 0] end, actual-num-of-xs)
+  var num-dot-chart-i = 0
+  for each2(x-value from labels, y-value from values):
+    for each(y-value-i from range(1, y-value + 1)) block:
+       raw-array-set(num-dot-chart-args-ra, num-dot-chart-i,
+         [raw-array: x-value, y-value-i])
+       num-dot-chart-i := num-dot-chart-i + 1
+    end
+  end
+  num-dot-chart-args = raw-array-to-list(num-dot-chart-args-ra)
+  # spy: num-dot-chart-args end
+  scatter-plot-from-list(map(lam(x1y1): raw-array-get(x1y1, 0) end, num-dot-chart-args),
+    map(lam(x1y1): raw-array-get(x1y1, 1) end, num-dot-chart-args))
+end
+
+fun old-num-dot-chart-bin(labels :: P.LoN, values :: P.LoN,
+      min-x-value :: Number, max-x-value :: Number) block:
   labels-length = labels.length()
   median-index = labels-length / 2
   sorted-labels = labels.sort()
@@ -1988,6 +2006,7 @@ fun num-dot-chart-from-list(labels :: P.LoN, values :: P.LoN) -> DataSeries bloc
   any-x-value = labels.get(0)
   min-x-value = fold(num-min, any-x-value, labels)
   max-x-value = fold(num-max, any-x-value, labels)
+  # create a binned chart if x range is large or if some x's are noninteger
   if (not(all(num-is-integer, labels)) or ((max-x-value - min-x-value) > 15)): 
     num-dot-chart-bin(labels, values, min-x-value, max-x-value)
   else:

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -1942,17 +1942,25 @@ fun num-dot-chart-bin(labels :: P.LoN, values :: P.LoN,
   sorted-labels-2nd-half = sorted-labels.split-at(num-ceiling(median-index)).suffix
   sorted-labels-iqr = ST.median(sorted-labels-2nd-half) -
                         ST.median(sorted-labels-1st-half)
+  # bin width based on Freedman-Diaconis rule
   dot-chart-bin-width-1 = ((2 * sorted-labels-iqr) /
                             num-expt(labels-length, 1/3))
+  # if bin width > 1, make it an even int
   dot-chart-bin-width = if dot-chart-bin-width-1 > 1:
       num-round-even(dot-chart-bin-width-1) else: dot-chart-bin-width-1 end
   left-most-x-1 = min-x-value - (dot-chart-bin-width / 2)
-  left-most-x = if dot-chart-bin-width > 0.5: num-floor(left-most-x-1) else:
-                      left-most-x-1 end
+  # if all x's are positive, don't make first interval start negative
+  left-most-x-2 = if all(num-is-positive, labels) and num-is-negative(left-most-x-1):
+                      min-x-value else: left-most-x-1 end
+  # if bin width > 0.5, keep x's integral
+  left-most-x = if dot-chart-bin-width > 0.5: num-floor(left-most-x-2) else:
+                      left-most-x-2 end
   num-bins = num-ceiling((max-x-value - left-most-x) / dot-chart-bin-width)
   num-dot-chart-args = for map(range-iter from range(0, num-bins)):
-    [raw-array: num-to-string-digits(left-most-x +
-      (range-iter * dot-chart-bin-width), 2), 0]
+    [raw-array: "[" +
+      num-to-string(left-most-x + (range-iter * dot-chart-bin-width)) +
+      "," + num-to-string(left-most-x + ((range-iter + 1) * dot-chart-bin-width)) + ")",
+      0]
     end
   for each2(x-value from labels, y-value from values):
     x-index = num-min(num-floor((x-value - left-most-x) / dot-chart-bin-width),

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1624,20 +1624,23 @@
             // const circleR = toFixnum(get(combined[0], 'point-size'));
             const circleR = Number(circle0.getAttribute('r'));
             const offsetQuantum = 2 * circleR;
-            let lastX = false;
-            let currentNumOffsets = 0;
+            let prevDotArray = [];
+            function tooClose(x, y) {
+              return prevDotArray.some(function(n) {
+                return ((Math.abs(x - n[0]) < offsetQuantum) &&
+                  (Math.abs(y - n[1]) < offsetQuantum));
+              });
+            }
+
             circles.forEach((circle) => {
               // console.log('updating circle', i);
               const circleX = Number(circle.getAttribute('cx'));
-              if (lastX &&
-                (lastX === circleX || (circleX - lastX) < offsetQuantum)) {
-                // circle.setAttribute('cx', lastX); // if we don't want horiz stagger
-                currentNumOffsets++;
-              } else {
-                lastX = circleX; currentNumOffsets = 0;
+              let circleY = Number(circle.getAttribute('cy')) - 0.5*offsetQuantum;
+              while (tooClose(circleX, circleY)) {
+                circleY -= offsetQuantum;
               }
-              let circleY = Number(circle.getAttribute('cy'));
-              circleY -= (currentNumOffsets + 0.5) * offsetQuantum;
+
+              prevDotArray.push([circleX, circleY]);
 
               const circleElt = circle.cloneNode(false);
               circleElt.classList.add('__img_labels'); // tag for later gc

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1631,14 +1631,22 @@
               const circleX = Number(circle.getAttribute('cx'));
               if (lastX &&
                 (lastX === circleX || (circleX - lastX) < offsetQuantum)) {
-                circle.setAttribute('cx', lastX);
+                // circle.setAttribute('cx', lastX); // if we don't want horiz stagger
                 currentNumOffsets++;
               } else {
                 lastX = circleX; currentNumOffsets = 0;
               }
               let circleY = Number(circle.getAttribute('cy'));
               circleY -= (currentNumOffsets + 0.5) * offsetQuantum;
-              circle.setAttribute('cy', circleY);
+
+              const circleElt = circle.cloneNode(false);
+              circleElt.classList.add('__img_labels'); // tag for later gc
+              circleElt.setAttribute('cy', circleY);
+              circleElt.setAttribute('r', circleR);
+              circleElt.setAttribute('fill-opacity', 1);
+              Object.assign(circleElt, circle); // we should probably not steal *everything*...
+              circle.remove();
+              svgRoot.appendChild(circleElt);
             });
           }
         });

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1293,7 +1293,8 @@ ${labelRow}`;
 
     // ASSERT: if we're using custom images, *every* series will have idx 3 defined
     const hasImage = combined.every(p => get(p, 'ps').filter(p => p[3]).length > 0);
-    let dotChartP = false;
+    const dotChartP = combined.some(p => get(p, 'dot-chart'));
+    const replaceDefaultSVG = (hasImage || dotChartP);
 
     const options = {
       tooltip: {isHtml: true},
@@ -1310,14 +1311,10 @@ ${labelRow}`;
         });
         // If we have our own image, make the point small and transparent
         if (i < scatters.length) {
-          if (get(p, 'dot-chart')) {
-            // console.log('dot chart scatter plot found');
-            dotChartP = true;
-          }
           $.extend(seriesOptions, {
-            pointSize: (hasImage || dotChartP) ? 0.1 : toFixnum(get(p, 'point-size')),
+            pointSize: replaceDefaultSVG ? 0.1 : toFixnum(get(p, 'point-size')),
             lineWidth: 0,
-            dataOpacity: (hasImage || dotChartP) ? 0 : 1,
+            dataOpacity: replaceDefaultSVG ? 0 : 1,
           });
         } else if (i - scatters.length < lines.length) {
           $.extend(seriesOptions, {
@@ -1576,7 +1573,7 @@ ${labelRow}`;
             .append(redrawG);
         }
 
-        if(!hasImage && !dotChartP) { return; } // If we don't have images, our work is done!
+        if (!replaceDefaultSVG) { return; } // If we don't have images, our work is done!
         
         // if custom images are defined, use the image at that location
         // and overlay it atop each dot
@@ -1591,13 +1588,13 @@ ${labelRow}`;
           // This is brittle and needs to be revisited
           const svgRoot = chart.container.querySelector('svg');
           // const markers = svgRoot.children[3].children[2].children; from sbcContinuation
-          if (hasImage) {
           let markers;
           if(legendEnabled) {
             markers = svgRoot.children[2].children[2].children;
           } else {
             markers = svgRoot.children[1].children[2].children;
           }
+          if (hasImage) {
 
           const layout = chart.getChartLayoutInterface();
           // remove any labels that have previously been drawn
@@ -1625,7 +1622,7 @@ ${labelRow}`;
           }
 
           if (dotChartP) {
-            const circles = [...svgRoot.children[1].children[2].getElementsByTagName('circle')];
+            const circles = [...markers].filter(m => m.nodeName == 'circle');
             // console.log('circles=', circles);
             const numCircles = circles.length;
             const circle0 = circles[0];

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1423,6 +1423,13 @@
       options['trendlines'][0]['degree'] = trendlineDegree;
     }
 
+    if (dotChartP) {
+      options['vAxis'] = {
+        ticks: [],
+        minValue: 0,
+      }
+    }
+
     const pointshapeType = get(ser0, 'pointshapeType');
     const pointshapeSides = toFixnum(get(ser0, 'pointshapeSides'));
     const pointshapeDent = toFixnum(get(ser0, 'pointshapeDent'));
@@ -1610,28 +1617,29 @@
           }
 
           if (dotChartP) {
-            const circles = svgRoot.children[1].children[2].getElementsByTagName('circle');
+            const circles = [...svgRoot.children[1].children[2].getElementsByTagName('circle')];
             // console.log('circles=', circles);
             const numCircles = circles.length;
-            let offsetQuantum = 0;
-            let currentX = false;
+            const circle0 = circles[0];
+            // const circleR = toFixnum(get(combined[0], 'point-size'));
+            const circleR = Number(circle0.getAttribute('r'));
+            const offsetQuantum = 2 * circleR;
+            let lastX = false;
             let currentNumOffsets = 0;
-            for(let i = 0; i < numCircles; i++) {
-              const circle = circles[i];
+            circles.forEach((circle) => {
               // console.log('updating circle', i);
-              if (offsetQuantum === 0) {
-                offsetQuantum = 2* Number(circle.getAttribute('r'));
-              }
               const circleX = Number(circle.getAttribute('cx'));
-              if (currentX === circleX) {
+              if (lastX &&
+                (lastX === circleX || (circleX - lastX) < offsetQuantum)) {
+                circle.setAttribute('cx', lastX);
                 currentNumOffsets++;
               } else {
-                currentX = circleX; currentNumOffsets = 0;
+                lastX = circleX; currentNumOffsets = 0;
               }
-              const circleY = Number(circle.getAttribute('cy'));
-              circle.setAttribute('cy',
-                circleY - (currentNumOffsets + 0.5)*offsetQuantum);
-            }
+              let circleY = Number(circle.getAttribute('cy'));
+              circleY -= (currentNumOffsets + 0.5) * offsetQuantum;
+              circle.setAttribute('cy', circleY);
+            });
           }
         });
       },

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1241,6 +1241,7 @@
 
       const rowTemplate = new Array(combined.length * 4 + 1).fill(null);
       const intervalP = (i >= minIntervalIndex);
+      const dotChartP = Boolean(get(p, 'dot-chart'));
       if (!intervalP) {
         data.addRows(get(p, 'ps').map(row => {
           const currentRow = rowTemplate.slice();
@@ -1253,10 +1254,16 @@
             } else {
               labelRow = '';
             }
+            let labelRowY = null;
+            if (dotChartP) {
+              labelRowY = '';
+            } else {
+              labelRowY = `<p>y: <b>${currentRow[4*i + 1]}</b></p>`;
+            }
             currentRow[4*i + 2] = `<p>${legends[i]}</p>
 <p>x: <b>${currentRow[0]}</b></p>
-<p>y: <b>${currentRow[4*i + 1]}</b></p>
-              ${labelRow}`;
+${labelRowY}
+${labelRow}`;
             // leave currentRow[4*i + 3] and [4*i + 4] null
           }
           return currentRow;
@@ -1308,9 +1315,9 @@
             dotChartP = true;
           }
           $.extend(seriesOptions, {
-            pointSize: hasImage ? 1 : toFixnum(get(p, 'point-size')),
+            pointSize: (hasImage || dotChartP) ? 0.1 : toFixnum(get(p, 'point-size')),
             lineWidth: 0,
-            dataOpacity: hasImage ? 0 : 1,
+            dataOpacity: (hasImage || dotChartP) ? 0 : 1,
           });
         } else if (i - scatters.length < lines.length) {
           $.extend(seriesOptions, {
@@ -1427,6 +1434,7 @@
       options['vAxis'] = {
         ticks: [],
         minValue: 0,
+        maxValue: 10,
       }
     }
 
@@ -1621,8 +1629,8 @@
             // console.log('circles=', circles);
             const numCircles = circles.length;
             const circle0 = circles[0];
-            // const circleR = toFixnum(get(combined[0], 'point-size'));
-            const circleR = Number(circle0.getAttribute('r'));
+            const circleR = toFixnum(get(combined[0], 'point-size'));
+            // const circleR = Number(circle0.getAttribute('r'));
             const offsetQuantum = 2 * circleR;
             let prevDotArray = [];
             function tooClose(x, y) {
@@ -1635,7 +1643,7 @@
             circles.forEach((circle) => {
               // console.log('updating circle', i);
               const circleX = Number(circle.getAttribute('cx'));
-              let circleY = Number(circle.getAttribute('cy')) - 0.5*offsetQuantum;
+              let circleY = Number(circle.getAttribute('cy')) - 1.2*circleR;
               while (tooClose(circleX, circleY)) {
                 circleY -= offsetQuantum;
               }
@@ -1648,7 +1656,6 @@
               circleElt.setAttribute('r', circleR);
               circleElt.setAttribute('fill-opacity', 1);
               Object.assign(circleElt, circle); // we should probably not steal *everything*...
-              circle.remove();
               svgRoot.appendChild(circleElt);
             });
           }

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1428,6 +1428,7 @@ ${labelRow}`;
     }
 
     if (dotChartP) {
+      // dot charts don't need horiz grid or anything below the x axis
       options['vAxis'] = {
         ticks: [],
         minValue: 0,

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1428,7 +1428,10 @@ ${labelRow}`;
     }
 
     if (dotChartP) {
-      // dot charts don't need horiz grid or anything below the x axis
+      // ticks [] as we don't want horizontal grid lines;
+      // maxValue must be set to something as otherwise having
+      // all dots at y=0 causes vAxis to be centered at 0;
+      // we don't want any chart real estate below x-axis
       options['vAxis'] = {
         ticks: [],
         minValue: 0,

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -1286,6 +1286,7 @@
 
     // ASSERT: if we're using custom images, *every* series will have idx 3 defined
     const hasImage = combined.every(p => get(p, 'ps').filter(p => p[3]).length > 0);
+    let dotChartP = false;
 
     const options = {
       tooltip: {isHtml: true},
@@ -1302,6 +1303,10 @@
         });
         // If we have our own image, make the point small and transparent
         if (i < scatters.length) {
+          if (get(p, 'dot-chart')) {
+            // console.log('dot chart scatter plot found');
+            dotChartP = true;
+          }
           $.extend(seriesOptions, {
             pointSize: hasImage ? 1 : toFixnum(get(p, 'point-size')),
             lineWidth: 0,
@@ -1556,7 +1561,7 @@
             .append(redrawG);
         }
 
-        if(!hasImage) { return; } // If we don't have images, our work is done!
+        if(!hasImage && !dotChartP) { return; } // If we don't have images, our work is done!
         
         // if custom images are defined, use the image at that location
         // and overlay it atop each dot
@@ -1571,6 +1576,7 @@
           // This is brittle and needs to be revisited
           const svgRoot = chart.container.querySelector('svg');
           // const markers = svgRoot.children[3].children[2].children; from sbcContinuation
+          if (hasImage) {
           let markers;
           if(legendEnabled) {
             markers = svgRoot.children[2].children[2].children;
@@ -1601,6 +1607,32 @@
               svgRoot.appendChild(imageElt);
             });
           });
+          }
+
+          if (dotChartP) {
+            const circles = svgRoot.children[1].children[2].getElementsByTagName('circle');
+            // console.log('circles=', circles);
+            const numCircles = circles.length;
+            let offsetQuantum = 0;
+            let currentX = false;
+            let currentNumOffsets = 0;
+            for(let i = 0; i < numCircles; i++) {
+              const circle = circles[i];
+              // console.log('updating circle', i);
+              if (offsetQuantum === 0) {
+                offsetQuantum = 2* Number(circle.getAttribute('r'));
+              }
+              const circleX = Number(circle.getAttribute('cx'));
+              if (currentX === circleX) {
+                currentNumOffsets++;
+              } else {
+                currentX = circleX; currentNumOffsets = 0;
+              }
+              const circleY = Number(circle.getAttribute('cy'));
+              circle.setAttribute('cy',
+                circleY - (currentNumOffsets + 0.5)*offsetQuantum);
+            }
+          }
         });
       },
     };

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -1,4 +1,4 @@
-include color
+import color as C
 include chart
 include image
 
@@ -360,23 +360,23 @@ end
 # COLOR METHOD TESTS 
 ######################
 
-single-color = [list: red]
-rainbow-colors = [list: red, orange, yellow, green, blue, indigo, violet]
+single-color = [list: C.red]
+rainbow-colors = [list: C.red, C.orange, C.yellow, C.green, C.blue, C.indigo, C.violet]
 manual-colors = 
   [list: 
-    color(51, 72, 252, 0.57), color(195, 180, 104, 0.87), 
-    color(115, 23, 159, 0.24), color(144, 12, 138, 0.13), 
-    color(31, 132, 224, 0.83), color(166, 16, 72, 0.59), 
-    color(58, 193, 241, 0.98)]
-less-colors = [list: red, green, blue, orange, purple]
-more-colors = [list: red, green, blue, orange, purple, yellow, indigo, violet]
+    C.color(51, 72, 252, 0.57), C.color(195, 180, 104, 0.87),
+    C.color(115, 23, 159, 0.24), C.color(144, 12, 138, 0.13),
+    C.color(31, 132, 224, 0.83), C.color(166, 16, 72, 0.59),
+    C.color(58, 193, 241, 0.98)]
+less-colors = [list: C.red, C.green, C.blue, C.orange, C.purple]
+more-colors = [list: C.red, C.green, C.blue, C.orange, C.purple, C.yellow, C.indigo, C.violet]
 
 check "Color Methods: Single Bars":
-  render-image(single-bars.color(red)) satisfies is-image
-  render-image(single-bars-neg.color(green)) satisfies is-image
-  render-image(single-bars-rep.color(violet)) satisfies is-image
-  render-image(single-bars-roughall.color(orange)) satisfies is-image
-  render-image(single-bars-roughsome.color(cyan)) satisfies is-image
+  render-image(single-bars.color(C.red)) satisfies is-image
+  render-image(single-bars-neg.color(C.green)) satisfies is-image
+  render-image(single-bars-rep.color(C.violet)) satisfies is-image
+  render-image(single-bars-roughall.color(C.orange)) satisfies is-image
+  render-image(single-bars-roughsome.color(C.cyan)) satisfies is-image
 
   render-image(single-bars.colors(empty)) satisfies is-image
   render-image(single-bars.colors(single-color)) satisfies is-image
@@ -585,23 +585,23 @@ check "Pointer Method: Single Bars":
 
   render-image(
     single-bars.add-pointers([list: 6, 7], [list: "median", "mean + 1"])
-               .pointer-color(red)) 
+               .pointer-color(C.red))
     satisfies is-image
   render-image(
     single-bars-neg.add-pointers([list: 3, 1, -2, -5], [list: "a", "b", "c", "d"])
-                   .pointer-color(green)) 
+                   .pointer-color(C.green))
     satisfies is-image
   render-image(
     single-bars-rep.add-pointers([list: 3, 5], [list: 'tres', 'cinco'])
-                   .pointer-color(cyan)) 
+                   .pointer-color(C.cyan))
     satisfies is-image
   render-image(
     single-bars-roughall.add-pointers([list: 11, 1, -5], [list: "a", "c", "d"])
-                        .pointer-color(magenta))
+                        .pointer-color(C.magenta))
     satisfies is-image
   render-image(
     single-bars-roughsome.add-pointers([list: 40, 5], [list: 'cuarenta', 'cinco'])
-                         .pointer-color(orange))
+                         .pointer-color(C.orange))
     satisfies is-image
 
   render-image(single-bars.add-pointers(empty, [list: "base"]))
@@ -671,28 +671,28 @@ check "Pointer Methods: Grouped Bars":
   render-image(
     grouped-bars.add-pointers([list: 1874094, 41417373 / 14], 
                               [list: "median (All Bars)", "mean (All Bars)"])
-               .pointer-color(red)) 
+               .pointer-color(C.red))
     satisfies is-image
   render-image(
     grouped-bars-neg.add-pointers([list: 0.3, 0, -1.5, -3], 
                                   [list: "a", "b", "c", "d"])
-                   .pointer-color(magenta)) 
+                   .pointer-color(C.magenta))
     satisfies is-image
   render-image(
     grouped-bars-rep.add-pointers([list: 3.5, 9], [list: "Decimal", "Almost Max"])
-                   .pointer-color(yellow)) 
+                   .pointer-color(C.yellow))
     satisfies is-image
   render-image(
     grouped-bars-repgroups.add-pointers([list: 6, 9], [list: "~Mid", "~Max"])
-                          .pointer-color(orange)) 
+                          .pointer-color(C.orange))
     satisfies is-image
   render-image(
     grouped-bars-roughall.add-pointers([list: 11, 1, -5], [list: "a", "c", "d"])
-                        .pointer-color(red))
+                        .pointer-color(C.red))
     satisfies is-image
   render-image(
     grouped-bars-roughsome.add-pointers([list: 3, 5], [list: 'tres', 'cinco'])
-                         .pointer-color(cyan))
+                         .pointer-color(C.cyan))
     satisfies is-image
 
   render-image(grouped-bars.add-pointers(empty, [list: "base"]))
@@ -765,27 +765,27 @@ check "Pointers Methods: Stacked Bars":
 
   render-image(
     stacked-bars.add-pointers([list: 18409317.5, 20708686.5], [list: "median", "mean"])
-                .pointer-color(red)) 
+                .pointer-color(C.red))
     satisfies is-image
   render-image(
     stacked-bars-neg.add-pointers([list: 1.3, 0, -1.5, -3], [list: "a", "b", "c", "d"])
-                    .pointer-color(magenta)) 
+                    .pointer-color(C.magenta))
     satisfies is-image
   render-image(
     stacked-bars-rep.add-pointers([list: 3.5, 59], [list: "Decimal", "Almost Max"])
-                    .pointer-color(yellow)) 
+                    .pointer-color(C.yellow))
     satisfies is-image
   render-image(
     stacked-bars-repstacks.add-pointers([list: 31, 59], [list: "Almost Middle", "Almost Max"])
-                          .pointer-color(orange)) 
+                          .pointer-color(C.orange))
     satisfies is-image
   render-image(
     stacked-bars-roughall.add-pointers([list: 11, 1, -5], [list: "a", "c", "d"])
-                        .pointer-color(red))
+                        .pointer-color(C.red))
     satisfies is-image
   render-image(
     stacked-bars-roughsome.add-pointers([list: 3, 5], [list: 'tres', 'cinco'])
-                         .pointer-color(cyan))
+                         .pointer-color(C.cyan))
     satisfies is-image
 
   render-image(stacked-bars.add-pointers(empty, [list: "base"]))
@@ -1062,7 +1062,7 @@ check "Intervals: Single Bars":
     satisfies is-image
   render-image(single-bars.intervals([list: [list: 9, 11],
       [list: 1, 2, 3, 4, 5], [list: -1, -2], empty, empty, empty, empty])
-      .interval-color(orange))
+      .interval-color(C.orange))
     satisfies is-image
 end
 
@@ -1086,9 +1086,9 @@ check "Intervals: Multiple Bars":
   render-image(stacked-small-data.intervals(intervals)) satisfies is-image
   render-image(grouped-small-data.intervals(intervals)) satisfies is-image
 
-  render-image(stacked-small-data.intervals(intervals).interval-color(red)) 
+  render-image(stacked-small-data.intervals(intervals).interval-color(C.red))
     satisfies is-image
-  render-image(grouped-small-data.intervals(intervals).interval-color(green)) 
+  render-image(grouped-small-data.intervals(intervals).interval-color(C.green))
     satisfies is-image
 end
 
@@ -1103,7 +1103,7 @@ check "Error bars: Single Bars":
     satisfies is-image
   render-image(single-bars.error-bars([list: [list: -1, 1], [list: -1, 1],
       [list: -1, 2], [list: -1, 1], [list: -1, 1], [list: -1, 1],
-      [list: -1, 1]]).interval-color(purple))
+      [list: -1, 1]]).interval-color(C.purple))
     satisfies is-image
 end
 
@@ -1127,8 +1127,8 @@ check "Error bars: Multiple Bars":
   render-image(stacked-small-data.error-bars(error-amounts)) satisfies is-image
   render-image(grouped-small-data.error-bars(error-amounts)) satisfies is-image
 
-  render-image(stacked-small-data.error-bars(error-amounts).interval-color(red)) 
+  render-image(stacked-small-data.error-bars(error-amounts).interval-color(C.red))
     satisfies is-image
-  render-image(grouped-small-data.error-bars(error-amounts).interval-color(green)) 
+  render-image(grouped-small-data.error-bars(error-amounts).interval-color(C.green))
     satisfies is-image
 end

--- a/test-util/pyret-programs/charts/dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/dot-chart-test.arr
@@ -64,8 +64,8 @@ check "Dot chart, numerical data":
   n-zoo-more satisfies is-image
 end
 
-r-x-values = [list: 2.5, 10.2, 14.5, 44.4, 45.4, 80.9]
-r-y-values = [list:   2,  6,     3,    4,    7,   3]
+r-x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
+r-y-values = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
 r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
 
 r-zoo = render-image(r-zoo-series)

--- a/test-util/pyret-programs/charts/dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/dot-chart-test.arr
@@ -64,22 +64,22 @@ check "Dot chart, numerical data":
   n-zoo-more satisfies is-image
 end
 
-r-x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
-r-y-values = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
-r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
-
-r-zoo = render-image(r-zoo-series)
-r-zoo-red = render-image(r-zoo-series.colors(just-red))
-r-zoo-rainbow = render-image(r-zoo-series.colors(rainbow-colors))
-r-zoo-manual = render-image(r-zoo-series.colors(manual-colors))
-r-zoo-fewer = render-image(r-zoo-series.colors(fewer-colors))
-r-zoo-more = render-image(r-zoo-series.colors(more-colors))
-
-check "Binned dot chart":
-  r-zoo satisfies is-image
-  r-zoo-red satisfies is-image
-  r-zoo-rainbow satisfies is-image
-  r-zoo-manual satisfies is-image
-  r-zoo-fewer satisfies is-image
-  r-zoo-more satisfies is-image
-end
+# r-x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
+# r-y-values = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
+# r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
+#
+# r-zoo = render-image(r-zoo-series)
+# r-zoo-red = render-image(r-zoo-series.colors(just-red))
+# r-zoo-rainbow = render-image(r-zoo-series.colors(rainbow-colors))
+# r-zoo-manual = render-image(r-zoo-series.colors(manual-colors))
+# r-zoo-fewer = render-image(r-zoo-series.colors(fewer-colors))
+# r-zoo-more = render-image(r-zoo-series.colors(more-colors))
+#
+# check "Binned dot chart":
+#   r-zoo satisfies is-image
+#   r-zoo-red satisfies is-image
+#   r-zoo-rainbow satisfies is-image
+#   r-zoo-manual satisfies is-image
+#   r-zoo-fewer satisfies is-image
+#   r-zoo-more satisfies is-image
+# end

--- a/test-util/pyret-programs/charts/interval-chart-test.arr
+++ b/test-util/pyret-programs/charts/interval-chart-test.arr
@@ -1,4 +1,4 @@
-include color
+import color as C
 include chart
 include image
 
@@ -66,13 +66,13 @@ check "Different kinds of numbers":
 end
 
 check "Colors":
-  render-image(ser-no-rough.color(violet)) satisfies is-image
-  render-image(ser-some-ys-rough.color(indigo)) satisfies is-image
-  render-image(ser-some-ress-rough.color(blue)) satisfies is-image
-  render-image(ser-some-ys-some-ress-rough.color(green)) satisfies is-image
-  render-image(ser-all-ys-some-ress-rough.color(yellow)) satisfies is-image
-  render-image(ser-some-ys-all-ress-rough.color(orange)) satisfies is-image
-  render-image(ser-all-ys-all-ress-rough.color(red)) satisfies is-image
+  render-image(ser-no-rough.color(C.violet)) satisfies is-image
+  render-image(ser-some-ys-rough.color(C.indigo)) satisfies is-image
+  render-image(ser-some-ress-rough.color(C.blue)) satisfies is-image
+  render-image(ser-some-ys-some-ress-rough.color(C.green)) satisfies is-image
+  render-image(ser-all-ys-some-ress-rough.color(C.yellow)) satisfies is-image
+  render-image(ser-some-ys-all-ress-rough.color(C.orange)) satisfies is-image
+  render-image(ser-all-ys-all-ress-rough.color(C.red)) satisfies is-image
 end
 
 check "Different point sizes":
@@ -96,13 +96,13 @@ check "Different line widths":
 end
 
 check "Mix and match":
-  render-image(ser-no-rough.color(purple).point-size(10)) satisfies is-image
-  render-image(ser-some-ys-rough.color(green).lineWidth(2)) satisfies is-image
+  render-image(ser-no-rough.color(C.purple).point-size(10)) satisfies is-image
+  render-image(ser-some-ys-rough.color(C.green).lineWidth(2)) satisfies is-image
   render-image(ser-some-ress-rough.point-size(20).lineWidth(3)) satisfies is-image
-  render-image(ser-some-ys-some-ress-rough.color(blue).point-size(15).lineWidth(5)) satisfies is-image
-  render-image(ser-all-ys-some-ress-rough.color(orange).lineWidth(3).point-size(9)) satisfies is-image
-  render-image(ser-some-ys-all-ress-rough.lineWidth(2).point-size(2).color(indigo)) satisfies is-image
-  render-image(ser-all-ys-all-ress-rough.lineWidth(3.3).color(yellow).point-size(~2.718281828)) satisfies is-image
+  render-image(ser-some-ys-some-ress-rough.color(C.blue).point-size(15).lineWidth(5)) satisfies is-image
+  render-image(ser-all-ys-some-ress-rough.color(C.orange).lineWidth(3).point-size(9)) satisfies is-image
+  render-image(ser-some-ys-all-ress-rough.lineWidth(2).point-size(2).color(C.indigo)) satisfies is-image
+  render-image(ser-all-ys-all-ress-rough.lineWidth(3.3).color(C.yellow).point-size(~2.718281828)) satisfies is-image
 end
 
 check "Exceptions":

--- a/test-util/pyret-programs/charts/num-dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/num-dot-chart-test.arr
@@ -33,3 +33,7 @@ r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
 r-zoo = render-image(r-zoo-series)
 
 # Do r-zoo.display() to see resizable chart
+
+fun t():
+  r-zoo.display()
+end

--- a/test-util/pyret-programs/charts/num-dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/num-dot-chart-test.arr
@@ -25,28 +25,34 @@ fun render-image(series):
   render-chart(series)
 end
 
-# r-x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
-# r-y-values = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
+# x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
+# freqs    = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
 
-r-x-values = [list: 1,1,1,1,1,
-                    2,2,2,
-                    3,3,3,3,3,3,
-                    4,4,4,4,
-                    5,5,5,
-                    6,6,6,
-                    8,8,8,
-                    9,9,
-                    10,
-                    24,
-                    30]
+r1-x-values = [list: 1,1,1,1,1,
+                     2,2,2,
+                     3,3,3,3,3,3,
+                     4,4,4,4,
+                     5,5,5,
+                     6,6,6,
+                     8,8,8,
+                     9,9,
+                     10,
+                     24,
+                     30]
 
-# r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
-r-zoo-series = from-list.num-dot-chart(r-x-values)
+# r2-x-values is same as r1-x-values but in different order
+r2-x-values = [list: 1,2,3,4,5,6,8,9,10,24,30,
+                     1,2,3,4,5,6,8,9,
+                     1,2,3,4,5,6,8,
+                     1,  3,4,
+                     1,  3,
+                         3]
 
-r-zoo = render-image(r-zoo-series)
+r1-zoo-series = from-list.num-dot-chart(r1-x-values)
+r1-zoo = render-image(r1-zoo-series)
 
-# Do r-zoo.display() to see resizable chart
+r2-zoo-series = from-list.num-dot-chart(r2-x-values)
+r2-zoo = render-image(r2-zoo-series)
 
-fun t():
-  r-zoo.display()
-end
+fun t1(): r1-zoo.display() end
+fun t2(): r2-zoo.display() end

--- a/test-util/pyret-programs/charts/num-dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/num-dot-chart-test.arr
@@ -1,0 +1,35 @@
+include chart
+include image
+import color as C
+# include image-structs
+include math
+
+labels = [list: "cats", "dogs", "ants", "elephants"]
+count = [list: 3, 7, 4, 9]
+
+# zoo-series = from-list.dot-chart(labels, count)
+
+just-red = [list: C.red]
+rainbow-colors = [list: C.red, C.orange, C.yellow, C.green, C.blue, C.indigo, C.violet]
+manual-colors =
+  [list:
+    C.color(51, 72, 252, 0.57), C.color(195, 180, 104, 0.87),
+    C.color(115, 23, 159, 0.24), C.color(144, 12, 138, 0.13),
+    C.color(31, 132, 224, 0.83), C.color(166, 16, 72, 0.59),
+    C.color(58, 193, 241, 0.98)]
+fewer-colors = [list: C.red, C.green, C.blue, C.orange, C.purple]
+more-colors = [list: C.red, C.green, C.blue, C.orange, C.purple, C.yellow, C.indigo, C.violet]
+
+fun render-image(series):
+  # render-chart(series).get-image()
+  render-chart(series)
+end
+
+r-x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
+r-y-values = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
+
+r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
+
+r-zoo = render-image(r-zoo-series)
+
+# Do r-zoo.display() to see resizable chart

--- a/test-util/pyret-programs/charts/num-dot-chart-test.arr
+++ b/test-util/pyret-programs/charts/num-dot-chart-test.arr
@@ -25,10 +25,23 @@ fun render-image(series):
   render-chart(series)
 end
 
-r-x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
-r-y-values = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
+# r-x-values = [list: 1, 2, 3, 4, 5, 6, 8, 9, 10, 24, 30]
+# r-y-values = [list: 5, 3, 6, 4, 3, 3, 3, 2,  1,  1,  1]
 
-r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
+r-x-values = [list: 1,1,1,1,1,
+                    2,2,2,
+                    3,3,3,3,3,3,
+                    4,4,4,4,
+                    5,5,5,
+                    6,6,6,
+                    8,8,8,
+                    9,9,
+                    10,
+                    24,
+                    30]
+
+# r-zoo-series = from-list.num-dot-chart(r-x-values, r-y-values)
+r-zoo-series = from-list.num-dot-chart(r-x-values)
 
 r-zoo = render-image(r-zoo-series)
 


### PR DESCRIPTION
Adds `num-dot-chart-from-list` for numerical (in contrast to categorical) dot charts.  It takes a list of numbers, which may repeat and need not be ordered, and creates a dot chart that responds to chart resizing by piling up the dots vertically when there isn't enough horizontal elbow room for different dots not to overlap. Even when a dot climbs up vertically, its x-position remains true. Also, if a dot's x-value precedes another in the input, then when one ends up piled atop the other, the left dot is lower than the right dot.