### PR TITLE
url(...) dependency locators for CPO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ PORT=4999
 NODE_ENV=development
 POSTMESSAGE_ORIGIN="http://localhost:3000"
 SHARED_FETCH_SERVER="https://code.pyret.org"
+URL_FILE_MODE="all-remote"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "colorspaces": "0.1.4",
         "cookie-parser": "^1.4.6",
         "cookie-session": "^1.4.0",
+        "cross-fetch": "^4.1.0",
         "css-loader": "^3.6.0",
         "csurf": "^1.11.0",
         "d3": "^3.5.17",
@@ -10698,6 +10699,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "6.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "node-uuid": "^1.4.8",
         "popper.js": "^1.16.1",
         "pyret-codemirror-mode": "github:brownplt/pyret-codemirror-mode#master",
-        "pyret-lang": "github:brownplt/pyret-lang#url-import",
+        "pyret-lang": "github:brownplt/pyret-lang#horizon",
         "q": "~1.4.1",
         "react": "^15.7.0",
         "react-dom": "^15.7.0",
@@ -17274,7 +17274,7 @@
     },
     "node_modules/pyret-lang": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/brownplt/pyret-lang.git#10b413d445e18858c1cf096aa55c783edae3fdef",
+      "resolved": "git+ssh://git@github.com/brownplt/pyret-lang.git#240e50a0da654c3762b7be37c3683313b6ea3269",
       "bundleDependencies": [
         "browserify"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "node-uuid": "^1.4.8",
         "popper.js": "^1.16.1",
         "pyret-codemirror-mode": "github:brownplt/pyret-codemirror-mode#master",
-        "pyret-lang": "github:brownplt/pyret-lang#horizon",
+        "pyret-lang": "github:brownplt/pyret-lang#url-import",
         "q": "~1.4.1",
         "react": "^15.7.0",
         "react-dom": "^15.7.0",
@@ -17274,7 +17274,7 @@
     },
     "node_modules/pyret-lang": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/brownplt/pyret-lang.git#b88c846e7827790d58b3b82f4ce52fac9bebde8d",
+      "resolved": "git+ssh://git@github.com/brownplt/pyret-lang.git#10b413d445e18858c1cf096aa55c783edae3fdef",
       "bundleDependencies": [
         "browserify"
       ],
@@ -17287,6 +17287,7 @@
         "canvas": "^3.1.0",
         "command-line-args": "^3.0.5",
         "command-line-usage": "^4.0.1",
+        "cross-fetch": "^4.1.0",
         "error-stack-parser": "^2.1.4",
         "fast-csv": "^5.0.2",
         "http": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node-uuid": "^1.4.8",
     "popper.js": "^1.16.1",
     "pyret-codemirror-mode": "github:brownplt/pyret-codemirror-mode#master",
-    "pyret-lang": "github:brownplt/pyret-lang#horizon",
+    "pyret-lang": "github:brownplt/pyret-lang#url-import",
     "q": "~1.4.1",
     "react": "^15.7.0",
     "react-dom": "^15.7.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "colorspaces": "0.1.4",
     "cookie-parser": "^1.4.6",
     "cookie-session": "^1.4.0",
+    "cross-fetch": "^4.1.0",
     "css-loader": "^3.6.0",
     "csurf": "^1.11.0",
     "d3": "^3.5.17",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node-uuid": "^1.4.8",
     "popper.js": "^1.16.1",
     "pyret-codemirror-mode": "github:brownplt/pyret-codemirror-mode#master",
-    "pyret-lang": "github:brownplt/pyret-lang#url-import",
+    "pyret-lang": "github:brownplt/pyret-lang#horizon",
     "q": "~1.4.1",
     "react": "^15.7.0",
     "react-dom": "^15.7.0",

--- a/src/scripts/npm-dependencies.js
+++ b/src/scripts/npm-dependencies.js
@@ -37,6 +37,9 @@ define("canvas", [], function() {
   };
 });
 
+crossfetch = require("cross-fetch");
+define("cross-fetch", [], function() { return crossfetch; });
+
 colorspaces = require("colorspaces");
 define("colorspaces", [], function () { return colorspaces; });
 

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -489,7 +489,7 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
 </script>
 <script src="{{ &BASE_URL }}/js/events.js"></script>
 <script>
-var URL_FILE_MODE = "{{ URL_FILE_MODE }}";
+var URL_FILE_MODE = window.URL_FILE_MODE = "{{ URL_FILE_MODE }}";
 </script>
 
   </main>

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -488,6 +488,9 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
 });
 </script>
 <script src="{{ &BASE_URL }}/js/events.js"></script>
+<script>
+var URL_FILE_MODE = "{{ URL_FILE_MODE }}";
+</script>
 
   </main>
 </body>

--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -387,50 +387,56 @@ $(function() {
     If the url does have a #program or #share, the promise is for the
     corresponding object.
   */
-  var initialProgram = storageAPI.then(function(api) {
-    var programLoad = null;
-    if(params["get"] && params["get"]["program"]) {
-      enableFileOptions();
-      programLoad = api.getFileById(params["get"]["program"]);
-      programLoad.then(function(p) { showShareContainer(p); });
-    }
-    else if(params["get"] && params["get"]["share"]) {
-      logger.log('shared-program-load',
-        {
-          id: params["get"]["share"]
-        });
-      programLoad = api.getSharedFileById(params["get"]["share"]);
-      programLoad.then(function(file) {
-        // NOTE(joe): If the current user doesn't own or have access to this file
-        // (or isn't logged in) this will simply fail with a 401, so we don't do
-        // any further permission checking before showing the link.
-        file.getOriginal().then(function(response) {
-          console.log("Response for original: ", response);
-          var original = $("#open-original").show().off("click");
-          var id = response.result.value;
-          original.removeClass("hidden");
-          original.click(function() {
-            window.open(window.APP_BASE_URL + "/editor#program=" + id, "_blank");
+  let initialProgram;
+  if(params["get"] && params["get"]["shareurl"]) {
+    initialProgram = makeUrlFile(params["get"]["shareurl"]);
+  }
+  else {
+    initialProgram = storageAPI.then(function(api) {
+      var programLoad = null;
+      if(params["get"] && params["get"]["program"]) {
+        enableFileOptions();
+        programLoad = api.getFileById(params["get"]["program"]);
+        programLoad.then(function(p) { showShareContainer(p); });
+      }
+      else if(params["get"] && params["get"]["share"]) {
+        logger.log('shared-program-load',
+          {
+            id: params["get"]["share"]
+          });
+        programLoad = api.getSharedFileById(params["get"]["share"]);
+        programLoad.then(function(file) {
+          // NOTE(joe): If the current user doesn't own or have access to this file
+          // (or isn't logged in) this will simply fail with a 401, so we don't do
+          // any further permission checking before showing the link.
+          file.getOriginal().then(function(response) {
+            console.log("Response for original: ", response);
+            var original = $("#open-original").show().off("click");
+            var id = response.result.value;
+            original.removeClass("hidden");
+            original.click(function() {
+              window.open(window.APP_BASE_URL + "/editor#program=" + id, "_blank");
+            });
           });
         });
-      });
-    }
-    else {
-      programLoad = null;
-    }
-    if(programLoad) {
-      programLoad.fail(function(err) {
-        console.error(err);
-        window.stickError("The program failed to load.");
-      });
-      return programLoad;
-    } else {
+      }
+      else {
+        programLoad = null;
+      }
+      if(programLoad) {
+        programLoad.fail(function(err) {
+          console.error(err);
+          window.stickError("The program failed to load.");
+        });
+        return programLoad;
+      } else {
+        return null;
+      }
+    }).catch(e => {
+      console.error("storageAPI failed to load, proceeding without saving programs: ", e);
       return null;
-    }
-  }).catch(e => {
-    console.error("storageAPI failed to load, proceeding without saving programs: ", e);
-    return null;
-  });
+    });
+  }
 
   function setTitle(progName) {
     document.title = progName + " - code.pyret.org";
@@ -1326,7 +1332,8 @@ $(function() {
 
   });
 
-  programLoaded.fail(function() {
+  programLoaded.fail(function(error) {
+    console.error("Program contents did not load: ", error);
     CPO.documents.set("definitions://", CPO.editor.cm.getDoc());
   });
 

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -14,6 +14,10 @@
     },
     { "import-type": "dependency",
       protocol: "file",
+      args: ["../../../pyret/src/arr/compiler/locators/url.arr"]
+    },
+    { "import-type": "dependency",
+      protocol: "file",
       args: ["../arr/cpo.arr"]
     },
     { "import-type": "dependency",
@@ -54,7 +58,7 @@
     }
   },
   theModule: function(runtime, namespace, uri,
-                      compileLib, compileStructs, pyRepl, cpo, replUI, textHandlers,
+                      compileLib, compileStructs, pyRepl, urlLoc, cpo, replUI, textHandlers,
                       parsePyret, runtimeLib, loadLib, builtinModules, cpoBuiltins,
                       gdriveLocators, fileLocator, http, cpoModules, _modalPrompt,
                       rtLib) {
@@ -207,6 +211,9 @@
                 else if (protocol === "file" && window.MESSAGES) {
                   var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
                   return fileLocatorConstructor.makeFileLocator(arr[0]);
+                }
+                else if (protocol === "url") {
+                  return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(arr[0], replGlobals);
                 }
                 /*
                 else if (protocol === "js-http") {

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -167,6 +167,12 @@
                 });
               });
             }
+            else if (protocol === "url") {
+              return arr[0];
+            }
+            else if (protocol === "url-file") {
+              return arr[0] + "/" + arr[1];
+            }
             else {
               console.error("Unknown import: ", dependency);
               return protocol + "://" + arr.join(":");

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -303,6 +303,7 @@
     var defaultOptions = gmf(compileStructs, "default-compile-options");
 
     var replP = Q.defer();
+    debugger;
     const urlFileMode = window.URL_FILE_MODE || "all-remote";
     return runtime.safeCall(function() {
         return gmf(cpo, "make-repl").app(

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -219,20 +219,32 @@
                   return fileLocatorConstructor.makeFileLocator(arr[0]);
                 }
                 else if (protocol === "url") {
+                  fetch(arr[0]).then(async (response) => {
+                    CPO.documents.set(arr[0], new CodeMirror.Doc(await response.text(), "pyret"));
+                  });
                   return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(arr[0], replGlobals);
                 }
                 else if (protocol === "url-file") {
                   const fullUrl = arr[0] + "/" + arr[1];
                   switch(urlFileMode) {
                     case "all-remote":
+                      fetch(fullUrl).then(async (response) => {
+                        CPO.documents.set(fullUrl, new CodeMirror.Doc(await response.text(), "pyret"));
+                      });
                       return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(fullUrl, replGlobals);
                     case "all-local":
+                      window.MESSAGES.sendRpc('fs', 'readFile', [fullUrl, 'utf8']).then((contents) => {
+                        CPO.documents.set(fullUrl, new CodeMirror.Doc(contents, "pyret"));
+                      });
                       var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
                       return fileLocatorConstructor.makeFileLocator(arr[1]);
                     case "local-if-present":
                       return runtime.pauseStack(async (restarter) => {
                         const exists = await window.MESSAGES.sendRpc('fs', 'exists', [arr[1]]);
                         if(exists) {
+                          window.MESSAGES.sendRpc('fs', 'readFile', [fullUrl, 'utf8']).then((contents) => {
+                            CPO.documents.set(fullUrl, new CodeMirror.Doc(contents, "pyret"));
+                          });
                           return runtime.runThunk(() => {
                             var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
                             return fileLocatorConstructor.makeFileLocator(arr[1]);
@@ -246,6 +258,9 @@
                           });
                         }
                         else {
+                          fetch(fullUrl).then(async (response) => {
+                            CPO.documents.set(fullUrl, new CodeMirror.Doc(await response.text(), "pyret"));
+                          });
                           return restarter.resume(runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(fullUrl, replGlobals));
                         }
                       });

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -303,7 +303,6 @@
     var defaultOptions = gmf(compileStructs, "default-compile-options");
 
     var replP = Q.defer();
-    debugger;
     const urlFileMode = window.URL_FILE_MODE || "all-remote";
     return runtime.safeCall(function() {
         return gmf(cpo, "make-repl").app(

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -215,6 +215,10 @@
                 else if (protocol === "url") {
                   return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(arr[0], replGlobals);
                 }
+                else if (protocol === "url-file") {
+                  const fullUrl = arr[0] + "/" + arr[1];
+                  return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(fullUrl, replGlobals);
+                }
                 /*
                 else if (protocol === "js-http") {
                   // TODO: THIS IS WRONG with the new locator system

--- a/src/web/js/cpo-main.js
+++ b/src/web/js/cpo-main.js
@@ -176,7 +176,7 @@
 
     }
 
-    function makeFindModule() {
+    function makeFindModule(urlFileMode) {
       // The locatorCache memoizes locators for the duration of an
       // interactions run
       var locatorCache = {};
@@ -217,7 +217,33 @@
                 }
                 else if (protocol === "url-file") {
                   const fullUrl = arr[0] + "/" + arr[1];
-                  return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(fullUrl, replGlobals);
+                  switch(urlFileMode) {
+                    case "all-remote":
+                      return runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(fullUrl, replGlobals);
+                    case "all-local":
+                      var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
+                      return fileLocatorConstructor.makeFileLocator(arr[1]);
+                    case "local-if-present":
+                      return runtime.pauseStack(async (restarter) => {
+                        const exists = await window.MESSAGES.sendRpc('fs', 'exists', [arr[1]]);
+                        if(exists) {
+                          return runtime.runThunk(() => {
+                            var fileLocatorConstructor = fileLocator.makeFileLocatorConstructor(window.MESSAGES.sendRpc, runtime, compileLib, compileStructs, parsePyret, builtinModules, cpo);
+                            return fileLocatorConstructor.makeFileLocator(arr[1]);
+                          }, (result) => {
+                            if(runtime.isSuccessResult(result)) {
+                              restarter.resume(result.result);
+                            }
+                            else {
+                              restarter.error(result.error);
+                            }
+                          });
+                        }
+                        else {
+                          return restarter.resume(runtime.getField(runtime.getField(urlLoc, "values"), "url-locator").app(fullUrl, replGlobals));
+                        }
+                      });
+                  }
                 }
                 /*
                 else if (protocol === "js-http") {
@@ -271,12 +297,13 @@
     var defaultOptions = gmf(compileStructs, "default-compile-options");
 
     var replP = Q.defer();
+    const urlFileMode = window.URL_FILE_MODE || "all-remote";
     return runtime.safeCall(function() {
         return gmf(cpo, "make-repl").app(
             builtinsForPyret,
             pyRuntime,
             pyRealm,
-            runtime.makeFunction(makeFindModule));
+            runtime.makeFunction(() => makeFindModule(urlFileMode)));
       }, function(repl) {
         var jsRepl = {
           runtime: runtime.getField(pyRuntime, "runtime").val,

--- a/src/web/js/google-apis/drive.js
+++ b/src/web/js/google-apis/drive.js
@@ -160,6 +160,9 @@ window.createProgramCollectionAPI = function createProgramCollectionAPI(collecti
       getFileById: function(id) {
         return drive.files.get({fileId: id}).then(fileBuilder);
       },
+      makeUrlFile: function(url) {
+        return makeUrlFile(url);
+      },
       getFileByName: function(name) {
         return this.getAllFiles().then(function(files) {
           return files.filter(function(f) { return f.getName() === name; });
@@ -316,4 +319,38 @@ window.createProgramCollectionAPI = function createProgramCollectionAPI(collecti
                 ret.resolve(initialize(drive));
               }});
   return ret.promise;
+}
+
+function makeUrlFile(url) {
+  const p = Q.defer();
+  p.resolve({
+    shared: true,
+    getOriginal: function() {
+      throw new Error("Cannot getOriginal for a file created from a URL")
+    },
+    getContents: function() {
+      const ans = Q.defer();
+      fetch(url).then(async function(contents) {
+        ans.resolve(await contents.text());
+      })
+      .catch(function(err) {
+        ans.reject(err);
+      });
+      return ans.promise;
+    },
+    getName: function() {
+      const lastSlash = String(url).lastIndexOf("/");
+      if(lastSlash === -1) {
+        return url;
+      }
+      return url.slice(lastSlash + 1);
+    },
+    getModifiedTime: function() {
+      return new Date();
+    },
+    getUniqueId: function() {
+      return url;
+    }
+  });
+  return p.promise;
 }

--- a/test-util/pyret-programs/modules/url-file-test-lib.arr
+++ b/test-util/pyret-programs/modules/url-file-test-lib.arr
@@ -1,0 +1,8 @@
+
+provide *
+
+x = "provided from url-file-test-lib"
+
+check:
+    x is "provided from url-file-test-lib"
+end

--- a/test-util/pyret-programs/modules/url-file.arr
+++ b/test-util/pyret-programs/modules/url-file.arr
@@ -1,0 +1,7 @@
+use context starter2024
+
+import url("https://raw.githubusercontent.com/brownplt/code.pyret.org/refs/heads/horizon/test-util/pyret-programs/modules/url-file-test-lib.arr") as U 
+
+check:
+    U.x is "provided from url-file-test-lib"
+end

--- a/test-util/pyret-programs/modules/url-file.arr
+++ b/test-util/pyret-programs/modules/url-file.arr
@@ -1,6 +1,6 @@
 use context starter2024
 
-import url("https://raw.githubusercontent.com/brownplt/code.pyret.org/refs/heads/horizon/test-util/pyret-programs/modules/url-file-test-lib.arr") as U 
+import url("https://raw.githubusercontent.com/brownplt/code.pyret.org/refs/heads/url-import/test-util/pyret-programs/modules/url-file-test-lib.arr") as U 
 
 check:
     U.x is "provided from url-file-test-lib"


### PR DESCRIPTION
Conveniently, cross-fetch is one of the better polyfills, so the work on pyret-lang pretty transparently pays off here. We can just import the pyret implementation of url-locator and call it, and the underlying libraries do the right kind of browser fetch()