### PR TITLE
disable undo keyboard shortcuts if in VScode mode

### DIFF
--- a/src/web/js/beforePyret.js
+++ b/src/web/js/beforePyret.js
@@ -197,8 +197,7 @@ $(function() {
     console.log("Using keymap: ", CodeMirror.keyMap.default, "macDefault: ", CodeMirror.keyMap.macDefault, "mac: ", mac);
     const modifier = mac ? "Cmd" : "Ctrl";
 
-    var cmOptions = {
-      extraKeys: CodeMirror.normalizeKeyMap({
+    const extraKeys = {
         "Shift-Enter": function(cm) { runFun(cm.getValue()); },
         "Shift-Ctrl-Enter": function(cm) { runFun(cm.getValue()); },
         "Tab": "indentAuto",
@@ -211,7 +210,21 @@ $(function() {
         "Ctrl-Right": "goForwardToken",
         [`${modifier}-F`]: "findPersistent",
         [`${modifier}-/`]: "toggleComment",
-      }),
+      };
+    if(window.PYRET_IN_VSCODE) {
+      // Disable undo and redo in vscode, since they mess with the host editor's undo/redo stack
+      // Oddly, it doesn't seem to work to add these to extraKeys; I have to
+      // override them in the default keymap
+      CodeMirror.keyMap.default[`${modifier}-Z`] = false;
+      CodeMirror.keyMap.default[`Shift-${modifier}-Z`] = false;
+      CodeMirror.keyMap.default[`${modifier}-Y`] = false;
+      // Ctrl-U is Undo within a range
+      CodeMirror.keyMap.default[`${modifier}-U`] = false;
+    }
+
+    var cmOptions = {
+      keyMap: 'default',
+      extraKeys: CodeMirror.normalizeKeyMap(extraKeys),
       indentUnit: 2,
       tabSize: 2,
       viewportMargin: Infinity,
@@ -1469,6 +1482,7 @@ $(function() {
   let initialState = params["get"]["initialState"];
 
   window.PYRET_IS_EMBEDDED = false;
+  window.PYRET_IN_VSCODE = false;
   if (typeof acquireVsCodeApi === "function") {
     window.MESSAGES = makeEvents({
       CPO: CPO,
@@ -1477,6 +1491,7 @@ $(function() {
       initialState
     });
     window.PYRET_IS_EMBEDDED = true;
+    window.PYRET_IN_VSCODE = true;
   }
   else if((window.parent && (window.parent !== window))) {
     window.MESSAGES = makeEvents({ CPO: CPO, sendPort: window.parent, receivePort: window, initialState });


### PR DESCRIPTION
VScode has its own definition of undo/redo that send direct updates to the `TextDocument` backing the editor.

If CodeMirror _also_ listens to these, then they fight a bit; for example, the `TextDocument` updates, which tries to propagate its changes to the CodeMirror instance, which has just processed an undo, which then sends a message to update the `TextDocument`. This is especially bad for updates that _undo to re-add text_, because it can get interpreted as a double-insertion.

So, let VScode be in charge of these events only, and respect the `TextDocument` as the model.