### PR TITLE
dcic2024.arr: provide string-{get-index,find{,-index,-opt}} from global

### DIFF
--- a/src/web/arr/trove/dcic2024.arr
+++ b/src/web/arr/trove/dcic2024.arr
@@ -16,6 +16,7 @@ import statistics as S
 #  import lists as L
 import sets as ST
 import constants as C
+import global as G
 
 provide: 
   get-row,
@@ -52,6 +53,13 @@ end
 
 provide from C:
   E
+end
+
+provide from G:
+  string-find-index,
+  string-find-opt,
+  string-find,
+  string-get-index,
 end
 
 # ----------- TABLE FUNCTIONS -----------


### PR DESCRIPTION
This PR has `dcic2024.arr` provide the functions
```
string-find
string-find-opt
string-find-index
string-get-index
```
from `global`. 


This is a fix for the pyret-lang issue https://github.com/brownplt/pyret-lang/issues/1824.